### PR TITLE
[fix] 火控升级扣款逻辑调整

### DIFF
--- a/packages/GFL_Castling/factions/default_base.character
+++ b/packages/GFL_Castling/factions/default_base.character
@@ -122,8 +122,8 @@
 	<comment key="skillcooldownhint" text="技能冷却还有&#37;time秒"/>
 	<comment key="skillcooldowndone" text="技能已就绪"/>
 	<comment key="onlyonequeue" text="您最多只能同时进行一个人形的心智升级--多余的火控核心已退还"/>
-	<comment key="digimindupdate" text="请将您需要心智升级的人形放入军械库，IOP将会处理后续的升级与改装"/>
-	<comment key="digimindupdatefailed" text="您提交的物品并不能进行心智升级，已将其与火控核心均退还给您"/>
+	<comment key="digimindupdate" text="请将您需要心智升级的人形放入军械库，IOP将会处理后续的升级与改装（需要10000 RP）"/>
+	<comment key="digimindupdatefailed" text="您提交的物品并不能进行心智升级，已将其与火控核心均退还给您，手续费恕不退款"/>
 	<comment key="digimindupdatesuccess" text="已完成人形&#37;doll_name的心智升级进程，为了更新世界的锋芒！"/>
 	<comment key="onlyonequeue_mask" text="您最多只能同时进行一项真核面具的兑换--多余的物品已退还"/>
 	<comment key="truemask" text="请输入(/mask 人形图鉴编号)，IOP会将对应人形发送到您的背包中"/>

--- a/packages/GFL_Castling/items/deprecated/merged_valuable.valuable
+++ b/packages/GFL_Castling/items/deprecated/merged_valuable.valuable
@@ -584,7 +584,7 @@
 
 <carry_item time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1.0" drop_count_factor_on_player_death="1.0" player_death_drop_owner_lock_time="90.0" name="Fire Control Component" key="firecontrol.carry_item">
 	<hud_icon filename="hud_firecontrol.png"/>
-	<inventory encumbrance="0.0" buy_price="500000" sell_price="-1000.0"/>
+	<inventory encumbrance="0.0" buy_price="50000" sell_price="0.0"/>
 	<model mesh_filename="fire_control.xml"/>
 	<commonness value="0" in_stock="0"/>
 </carry_item>

--- a/packages/GFL_Castling/items/firecontrol.carry_item
+++ b/packages/GFL_Castling/items/firecontrol.carry_item
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <carry_item time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1.0" drop_count_factor_on_player_death="1.0" player_death_drop_owner_lock_time="90.0" name="Fire Control Component" key="firecontrol.carry_item">
     <hud_icon filename="hud_firecontrol.png" />
-    <inventory encumbrance="0.0" buy_price="500000" sell_price="-10000.0"/>
+    <inventory encumbrance="0.0" buy_price="50000" sell_price="0.0"/>
     <model mesh_filename="fire_control.xml"/>
     <commonness value="0" in_stock="0" />
 </carry_item>

--- a/packages/GFL_Castling/items/valuable_item.carry_item
+++ b/packages/GFL_Castling/items/valuable_item.carry_item
@@ -410,7 +410,7 @@
 	</carry_item>
 	<carry_item time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1.0" drop_count_factor_on_player_death="1.0" player_death_drop_owner_lock_time="90.0" name="Fire Control Component" key="firecontrol.carry_item">
 		<hud_icon filename="hud_firecontrol.png" />
-		<inventory encumbrance="0.0" buy_price="500000" sell_price="-10000.0" />
+		<inventory encumbrance="0.0" buy_price="50000" sell_price="0.0" />
 		<model mesh_filename="fire_control.xml" />
 		<commonness value="0" in_stock="0" />
 	</carry_item>

--- a/packages/GFL_Castling/languages/en/default_base.character
+++ b/packages/GFL_Castling/languages/en/default_base.character
@@ -122,7 +122,7 @@
     <comment key="skillcooldownhint" text="Skill Cooldown has &#37;time seconds left"/>
 	<comment key="skillcooldowndone" text="Skill is done"/>
 	<comment key="onlyonequeue" text="You can only upgrade one t-doll at one time"/>
-	<comment key="digimindupdate" text="Submit the t-doll to armory, IOP will handle the digi-mind upgrade"/>
+	<comment key="digimindupdate" text="Submit the t-doll to armory, IOP will handle the digi-mind upgrade (requiring 10,000 RP)"/>
 	<comment key="digimindupdatefailed" text="The item you submitted cannot be upgraded"/>
 	<comment key="digimindupdatesuccess" text="&#37;doll_name digi-mind update finish. The shining beacon in a brave new world!"/>
 	<comment key="onlyonequeue_mask" text="You can only exchange one t-doll at one time"/>

--- a/packages/GFL_Castling/scripts/trackers/ItemDropEvent.as
+++ b/packages/GFL_Castling/scripts/trackers/ItemDropEvent.as
@@ -391,6 +391,7 @@ class ItemDropEvent : Tracker {
                             a["%doll_name"] = getResourceName(m_metagame, itemKey, "weapon");
                             sendPrivateMessageKey(m_metagame, pId, "digimindupdatesuccess",a);
                             playPrivateSound(m_metagame,"digimind_sfx2.wav",pId);
+                            GiveRP(m_metagame,cId,7500);
                             //下面是自动录入功能
                             GFL_playerInfo@ playerInfo = getPlayerInfoFromListbyPid(pId);
                             if (playerInfo.getPlayerName() == default_string) return;

--- a/packages/GFL_Castling/scripts/trackers/ItemDropEvent.as
+++ b/packages/GFL_Castling/scripts/trackers/ItemDropEvent.as
@@ -391,7 +391,7 @@ class ItemDropEvent : Tracker {
                             a["%doll_name"] = getResourceName(m_metagame, itemKey, "weapon");
                             sendPrivateMessageKey(m_metagame, pId, "digimindupdatesuccess",a);
                             playPrivateSound(m_metagame,"digimind_sfx2.wav",pId);
-                            GiveRP(m_metagame,cId,7500);
+                            GiveRP(m_metagame,cId,-2500);
                             //下面是自动录入功能
                             GFL_playerInfo@ playerInfo = getPlayerInfoFromListbyPid(pId);
                             if (playerInfo.getPlayerName() == default_string) return;
@@ -421,11 +421,12 @@ class ItemDropEvent : Tracker {
                             }
                         }
                         else{
-                            addItemInBackpack(m_metagame,cId,"carry_item","firecontrol.carry_item");;
+                            addItemInBackpack(m_metagame,cId,"carry_item","firecontrol.carry_item");
                             addItemInBackpack(m_metagame,cId,"weapon",itemKey);
                             m_craftQueue.removeAt(findQueueIndex(pId,"mod3"));
                             sendPrivateMessageKey(m_metagame, pId, "digimindupdatefailed");
                             playPrivateSound(m_metagame,"sfx_failed.wav",pId);
+                            GiveRP(m_metagame,cId,-10000);
                         }
                     }
                     else if (checkQueue(pId,"type88") && (itemKey=="gkw_88typemod3.weapon" 
@@ -731,9 +732,9 @@ class ItemDropEvent : Tracker {
                 c.setIntAttribute("container_type_id", 4);
                 c.setIntAttribute("character_id", cId); 
                 {
-                    XmlElement k("item");;
-                    k.setStringAttribute("class", "carry_item");;
-                    k.setStringAttribute("key", "exo_t5_16lab.carry_item");;
+                    XmlElement k("item");
+                    k.setStringAttribute("class", "carry_item");
+                    k.setStringAttribute("key", "exo_t5_16lab.carry_item");
                     c.appendChild(k);
                 }
                 m_metagame.getComms().send(c);

--- a/packages/GFL_Castling/weapons/merged_carry_item.carry_item
+++ b/packages/GFL_Castling/weapons/merged_carry_item.carry_item
@@ -13995,7 +13995,7 @@
 
 <carry_item time_to_live_out_in_the_open="90.0" drop_count_factor_on_death="1.0" drop_count_factor_on_player_death="1.0" player_death_drop_owner_lock_time="90.0" name="Fire Control Component" key="firecontrol.carry_item">
 	<hud_icon filename="hud_firecontrol.png"/>
-	<inventory encumbrance="0.0" buy_price="500000" sell_price="-10000.0"/>
+	<inventory encumbrance="0.0" buy_price="50000" sell_price="0.0"/>
 	<model mesh_filename="fire_control.xml"/>
 	<commonness value="0" in_stock="0"/>
 </carry_item>
@@ -27681,4 +27681,3 @@
 </carry_item>
 
 </carry_items>
-


### PR DESCRIPTION
火控扣款移动至处理脚本，现在成功改造扣款2500RP（降低真正升级的成本），失败扣款10000RP（与原先一致）。
理论上可以避免同时卖10个火控扣10w的情况，也可以避免刷钱。