### PR TITLE
[chore] 各种小加强

### DIFF
--- a/packages/GFL_Castling/factions/sf.xml
+++ b/packages/GFL_Castling/factions/sf.xml
@@ -838,7 +838,7 @@
             <call key="sf_mecha.call" />            
             <call key="sf_trooper_goliath.call" />
 			<weapon key="sfw_Intruder.weapon" enabled="1"/>
-			<!-- <projectile key="skill_sf_boss_intruder_spawn.projectile" enabled="1"/> -->
+			<projectile key="skill_sf_boss_intruder_spawn.projectile" enabled="1"/>
 			<carry_item key="vest_40hp.carry_item" enabled="1" />
 		</resources>
 		<attribute_config class="xp">

--- a/packages/GFL_Castling/languages/cn/GFL_call.xml
+++ b/packages/GFL_Castling/languages/cn/GFL_call.xml
@@ -503,7 +503,7 @@
 -标定目标点，5秒后开始火箭弹覆盖，每轮发射24发火箭弹，扩散范围35
 -持续9轮，每轮间隔3秒
 -从第二波开始每次覆盖都会有10半径的偏离，让打击面更广
--火箭在范围6.0造成10的blast伤害"/>
+-火箭在范围6.0造成15.1的blast伤害"/>
 
     <text key="Hint - call - title - call_ui_t2_kaguya_strike" text="耀夜姬 - 轨道激光打击" />
     <text key="Hint - call - intro - call_ui_t2_kaguya_strike" text="<冷却时间 120秒 消耗 35战术点>

--- a/packages/GFL_Castling/models/soldier_animations.xml
+++ b/packages/GFL_Castling/models/soldier_animations.xml
@@ -23426,7 +23426,7 @@
 			<position x="4.599201" y="-0.159432" z="13.712048" />
 		</frame>
 	</animation>
-	<animation loop="1" end="3.000000" speed="1.000000" comment="repairing vest">
+	<animation loop="1" end="3.000000" speed="1.666667" comment="repairing vest">
 		<frame time="0.000000">
 			<position x="-8.593827" y="24.019615" z="19.773434" />
 			<position x="-8.169551" y="19.056721" z="14.855136" />

--- a/packages/GFL_Castling/weapons/FF_sfw_dreamer.weapon
+++ b/packages/GFL_Castling/weapons/FF_sfw_dreamer.weapon
@@ -53,7 +53,7 @@
 
     <weak_hand_hold offset="0.4" />
     <projectile file="bullet_dreamer.projectile">
-        <result class="blast" radius="3.75" damage="3.1" decal="0" push="0.4" character_state="death" faction_compare="not_equal" make_vehicle_hit_sound="0" />
+        <result class="spawn" instance_class="projectile" instance_key="sub_damage_dreamer.projectile" min_amount="2" max_amount="2" offset="0 0.5 0" position_spread="0 0" direction_spread="0 0" />
     </projectile>
 
 	<stance state_key="running" accuracy="0.5" />
@@ -124,7 +124,7 @@
 
     <projectile file="mk153_HEAT.projectile">
 		<trail probability="1.0" key="laser_dreamer" />
-		<result class="blast" radius="6.0" damage="25.0" decal="1" push="0.4" character_state="death" faction_compare="not_equal"/>
+		<result class="blast" radius="6.0" damage="25.0" decal="1" push="0.4" character_state="death" faction_compare="not_equal" damage_origin_vehicle="0"/>
 	</projectile>
 
 	<stance state_key="running" accuracy="0.85" />

--- a/packages/GFL_Castling/weapons/ap.projectile
+++ b/packages/GFL_Castling/weapons/ap.projectile
@@ -545,6 +545,28 @@ player_death_drop_owner_lock_time="120"
 <projectile  
 class="grenade" 
 name="" 
+key="sub_damage_dreamer.projectile" 
+slot="0"
+pulldown_in_air="4.0"
+on_ground_up="0 1 0"
+use_time_to_live="1"
+time_to_live="15"
+can_be_disarmed="0"
+can_be_detected_by_footmen="1"
+can_be_detected_by_driver="1"
+radius="0.3"
+time_to_live_out_in_the_open="150"
+player_death_drop_owner_lock_time="120"
+>
+	<result class="blast" radius="3.75" damage="3.1" decal="0" push="0.2" character_state="death" faction_compare="not_equal" make_vehicle_hit_sound="0" damage_origin_vehicle="0"/>
+	<trigger class="time" time_to_live="0" />	
+    <rotation class="random" />
+	<model mesh_filename="" />
+	<commonness value="0.0" can_respawn_with="0" in_stock="0"/>
+</projectile>
+<projectile  
+class="grenade" 
+name="" 
 key="sub_damage_gm6.projectile" 
 slot="0"
 pulldown_in_air="4.0"

--- a/packages/GFL_Castling/weapons/gkw_323_sg_12g_ltlx7000_icecream.weapon
+++ b/packages/GFL_Castling/weapons/gkw_323_sg_12g_ltlx7000_icecream.weapon
@@ -37,7 +37,7 @@
     <hud_icon filename="gkw_ltlx7000_icecream.png" />
     <!--Ballistics-->
     <weak_hand_hold offset="0.3" />
-    <projectile file="icecream.projectile"/>
+    <projectile file="icecream_wound.projectile"/>
     <!--Accuracy, Movement speed-->
     <stance state_key="walking" accuracy="0.6" />
     <stance state_key="crouch_moving" accuracy="0.5" />

--- a/packages/GFL_Castling/weapons/gkw_special_cyclops.weapon
+++ b/packages/GFL_Castling/weapons/gkw_special_cyclops.weapon
@@ -12,11 +12,13 @@
     slot="0" 
     magazine_size="60" 
     name="Summer Killer" 
+    sight_range_modifier="1.5"
     projectile_speed="200.0" 
     retrigger_time="0.1" 
     suppressed="0" 
-    sustained_fire_diminish_rate="1.6" 
-    sustained_fire_grow_step="0.4" />
+    spread_range="0.35"
+    sustained_fire_diminish_rate="2.0" 
+    sustained_fire_grow_step="0.3" />
     <commonness value="0" in_stock="0" can_respawn_with="1" />
     <capacity value="1" source="rank" source_value="0.0" />
     <animation state_key="recoil" animation_key="recoil, hip fire" />
@@ -53,15 +55,15 @@
     <hud_icon filename="kccow_ar.png" />
     <weak_hand_hold offset="0.2" />
     <projectile file="bullet.projectile">
-        <result class="hit"  kill_probability="1.75" kill_probability_offset_on_successful_hit="1.7" kill_decay_start_time="1.125" kill_decay_end_time="1.875" />
+        <result class="hit"  kill_probability="2.5" kill_probability_offset_on_successful_hit="4.5" kill_decay_start_time="1.125" kill_decay_end_time="1.875" />
     </projectile>
     <effect class="muzzle" ref="ejection_76251" />
     <stance state_key="running" accuracy="0.5" />
     <stance state_key="walking" accuracy="0.6" />
     <stance state_key="crouch_moving" accuracy="0.8" />
     <stance state_key="prone_moving" accuracy="0.8" />
-    <stance state_key="standing" accuracy="0.75" />
-    <stance state_key="crouching" accuracy="0.8" />
+    <stance state_key="standing" accuracy="0.92" />
+    <stance state_key="crouching" accuracy="0.95" />
     <stance state_key="prone" accuracy="1" />
     <stance state_key="over_wall" accuracy="1" />
     <modifier class="detectability" value="-0.1" />

--- a/packages/GFL_Castling/weapons/icecream.projectile
+++ b/packages/GFL_Castling/weapons/icecream.projectile
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
+<projectiles>
 <projectile class="grenade" name="Ice cream" key="icecream.projectile" slot="0" radius="0.3" on_ground_up="0 1 0" use_time_to_live="1" time_to_live="10" can_be_disarmed="1" can_be_detected_by_driver="0" can_be_detected_by_footmen="0" drop_count_factor_on_death="0.0" time_to_live_out_in_the_open="10.0" blast_damage_threshold="0.05">
     <result class="blast" radius="2.0" damage="0.0" push="0.0" decal="0" character_state="stun" faction_compare="not_equal" />
     <collision class="sticky" />
@@ -17,3 +18,23 @@
     <capacity value="1" source="rank" source_value="0.0" />
     <sound class="result" key="character" fileref="slip.wav" volume="0.5" />
 </projectile>
+
+<projectile class="grenade" name="Ice cream" key="icecream_wound.projectile" slot="0" radius="0.3" on_ground_up="0 1 0" use_time_to_live="1" time_to_live="10" can_be_disarmed="0" can_be_detected_by_driver="0" can_be_detected_by_footmen="0" drop_count_factor_on_death="0.0" time_to_live_out_in_the_open="10.0" blast_damage_threshold="0.05">
+    <result class="blast" radius="2.0" damage="0.01" push="0.0" decal="0" character_state="wound" faction_compare="not_equal" />
+    <collision class="sticky" />
+    <trigger class="impact">
+        <collider class="terrain" enabled="0" />
+        <collider class="static_object" enabled="0" />
+        <collider class="vehicle" enabled="0" />
+        <collider class="character" enabled="1"/>
+    </trigger>
+    <rotation class="random" />
+    <model mesh_filename="icecream.xml" />
+    <hud_icon filename="hud_icecream.png" />
+    <throwable curve_height="2.0" near_far_distance="2.0" speed_estimation_near="5.0" speed_estimation_far="5.0" max_speed="5.0" randomness="0.01" />
+    <commonness value="0.0" can_respawn_with="0" in_stock="1" />
+    <inventory encumbrance="0.0" buy_price="15.0" sell_price="0.1" />
+    <capacity value="1" source="rank" source_value="0.0" />
+    <sound class="result" key="character" fileref="slip.wav" volume="0.5" />
+</projectile>
+</projectiles>


### PR DESCRIPTION
1. GK梦想家1模式弹头翻倍（该加强就是要加强，这东西23年的水平了）
2. 三合一修甲包动作速度提高 时间3s->2s（没敢给更高，看着再调）
3. ltlx冰淇淋枪换成wound冰淇淋，现在是接近废品的小玩具而不是废品
4. 夏日杀手加强，现在是小玩具而不是废品
5. SF干扰者拿回技能（我们依然不知道到底什么东西炸的服，你觉得有问题可以把兵蚁砍了，我觉得干扰器要留着）
6. 火箭弹覆盖文本更正（我查了半天bm21_122mm是15.1，为什么当初写的10）