### PR TITLE
[feat/chore] FF稻草人技能补完 and 部分FF武器加强

### DIFF
--- a/packages/GFL_Castling/factions/gk.xml
+++ b/packages/GFL_Castling/factions/gk.xml
@@ -1499,7 +1499,7 @@
 		<ai filename="dummy_scarecrow.ai" />
 		<resources clear_vehicles="1" clear_weapons="1" clear_grenades="1" clear_carry_items="1" clear_calls="1">
 			<weapon key="ff_scarecrow_dummy.weapon" />
-			<carry_item key="exo_t5_16lab.carry_item" />
+			<carry_item key="bp_t5_16lab.carry_item" />
 		</resources>
 		<attribute_config class="xp">
 			<attribute weight="0.3" min="0" max="0.1" />

--- a/packages/GFL_Castling/scripts/core/command_skill_info.as
+++ b/packages/GFL_Castling/scripts/core/command_skill_info.as
@@ -568,6 +568,9 @@ dictionary commandSkillIndex = {
         {"ff_parw_nyto_black.weapon",94},
         {"ff_parw_nyto_black_1.weapon",94},
 
+        {"ff_scarecrow.weapon",95},
+        {"ff_scarecrow_skill.weapon",95},
+
         // 下面这行是用来占位的，在这之上添加新的枪和index即可
         {"666",-1}
 };

--- a/packages/GFL_Castling/scripts/trackers/commandskill.as
+++ b/packages/GFL_Castling/scripts/trackers/commandskill.as
@@ -288,7 +288,7 @@ class CommandSkill : Tracker {
                 case 92:{excuteZasM21mod3Skill(cId,senderId,m_modifer);break;}
                 case 93:{excuteWebleySkill(cId,senderId,m_modifer);break;}
                 case 94:{excuteNytoBlackSkill(cId,senderId,m_modifer);break;}
-
+                case 95:{excuteScarecrowSkill(cId,senderId,m_modifer);break;}
                 
                 
                 default:
@@ -5152,6 +5152,30 @@ class CommandSkill : Tracker {
             TaskSequencer@ tasker = m_metagame.getTaskManager().newTaskSequencer();
             tasker.add(DelayNytoBlackSkillTask(m_metagame, 1.0, characterId, factionid, c_pos.add(Vector3(0,0.5,0)), s_pos, targets));
             addCooldown("NytoBlack",30,characterId,modifer);
+        }
+    }
+
+    void excuteScarecrowSkill(int characterId,int playerId,SkillModifer@ modifer){
+        if (excuteCooldownCheck(m_metagame,characterId,modifer,playerId,"scarecrow",true)) return;
+        const XmlElement@ character = getCharacterInfo(m_metagame, characterId);
+        if (character !is null) {
+            const XmlElement@ player = getPlayerInfo(m_metagame, playerId);
+            if (player !is null){
+                if (player.hasAttribute("aim_target")) {
+                    string target = player.getStringAttribute("aim_target");
+                    Vector3 aim_pos = stringToVector3(target);
+                    Vector3 c_pos = stringToVector3(character.getStringAttribute("position"));
+                    int factionid = character.getIntAttribute("faction_id");
+                    array<string> Voice={
+                        "Scarecrow_buhuo_SKILL01_JP.wav",
+                        "Scarecrow_buhuo_SKILL02_JP.wav",
+                        "Scarecrow_buhuo_SKILL03_JP.wav"
+                    };
+                    playRandomSoundArray(m_metagame,Voice,factionid,c_pos.toString(),1);
+                    spawnSoldier(m_metagame,1,faction_id,aim_pos,"Dummy_Scarecrow");
+                    addCooldown("scarecrow",20,characterId,modifer);
+                }
+            }
         }
     }
 }

--- a/packages/GFL_Castling/weapons/FF_sfw_agent.weapon
+++ b/packages/GFL_Castling/weapons/FF_sfw_agent.weapon
@@ -52,7 +52,7 @@
     <hud_icon filename="sfw_agent.png" />
     <weak_hand_hold offset="0.2" />
     <projectile file="bullet_sf_player.projectile">
-        <result class="blast"  damage="0.425" radius="3.75" decal="1" push="0.25" character_state="death" faction_compare="not_equal" damage_as_probability="1" />
+        <result class="blast"  damage="0.425" radius="3.75" decal="1" push="0.05" character_state="death" faction_compare="not_equal" damage_as_probability="1" />
     </projectile>
     <stance state_key="running" accuracy="0.85"/>
     <stance state_key="walking" accuracy="0.85"/>

--- a/packages/GFL_Castling/weapons/FF_sfw_alchemist.weapon
+++ b/packages/GFL_Castling/weapons/FF_sfw_alchemist.weapon
@@ -16,7 +16,7 @@
     carry_in_two_hands="0" 
 	suppressed="0"
 	name="GK-Alchemist"
-	class="4"
+	class="0"
 	sight_range_modifier="1.0"
 	projectile_speed="150"
 	projectiles_per_shot="2"

--- a/packages/GFL_Castling/weapons/FF_sfw_justice.weapon
+++ b/packages/GFL_Castling/weapons/FF_sfw_justice.weapon
@@ -13,6 +13,7 @@
         projectile_speed="200"
         retrigger_time="0.085"
         suppressed="0"
+        sight_range_modifier="1.5"
         spread_range="0.35"
         carry_in_two_hands="0"
         can_shoot_standing="1"
@@ -21,7 +22,7 @@
         projectiles_per_shot="2"
         stance_accuracy_rate="1.5"
         sustained_fire_diminish_rate="2"
-        sustained_fire_grow_step="0.45"
+        sustained_fire_grow_step="0.35"
     />
     <commonness value="0" in_stock="0" can_respawn_with="1" />
     <inventory encumbrance="25.0" buy_price="648.0" sell_price="648.0"/>

--- a/packages/GFL_Castling/weapons/FF_sfw_scarecrow.weapon
+++ b/packages/GFL_Castling/weapons/FF_sfw_scarecrow.weapon
@@ -55,7 +55,7 @@
     <hud_icon filename="sfw_scarecrow.png" />
     <weak_hand_hold offset="0.2" />
     <projectile file="bullet_sf_player.projectile">
-      <result class="hit" kill_probability="1.75" kill_probability_offset_on_successful_hit="2.5" kill_decay_start_time="0.2" kill_decay_end_time="0.6" />
+      <result class="hit" kill_probability="1.75" kill_probability_offset_on_successful_hit="3.5" kill_decay_start_time="0.2" kill_decay_end_time="0.6" />
       <trail probability="1.0" key="green" />
     </projectile>
     <stance state_key="running" accuracy="0.85" />
@@ -72,7 +72,7 @@
   <weapon key="ff_scarecrow_skill.weapon" on_ground_up="0 0 1" drop_count_factor_on_death="0" drop_count_factor_on_player_death="0" time_to_live_out_in_the_open="0">
     <tag name="elite" />
     <specification 
-        last_burst_retrigger_time="0.5"
+        last_burst_retrigger_time="0.33"
         retrigger_time="0.025" 
 		accuracy_factor="0.95" 
 		barrel_offset="0.5" 
@@ -195,7 +195,7 @@
     <hud_icon filename="sfw_scarecrow.png" />
     <weak_hand_hold offset="0.2" />
     <projectile file="bullet_sf_player.projectile">
-      <result class="hit" kill_probability="1.55" kill_probability_offset_on_successful_hit="1.0"  kill_decay_start_time="0.2" kill_decay_end_time="0.6" />
+      <result class="hit" kill_probability="0.0" kill_decay_start_time="0.2" kill_decay_end_time="0.6" />
       <trail probability="1.0" key="green" />
     </projectile>
     <stance state_key="running" accuracy="0.5" />
@@ -208,7 +208,6 @@
     <stance state_key="over_wall" accuracy="1" />
     <modifier class="detectability" value="1.0" />
     <modifier class="speed" value="1.0" />
-    <modifier class="hit_success_probability" value="-0.5" />
     <drop_on_death_result class="spawn" instance_class="projectile" instance_key="grenade_scarecrow.projectile" min_amount="1.0" max_amount="1.0" offset="0 0.2 0" position_spread="0 0" direction_spread="0 0"/>
   </weapon>
 </weapons>

--- a/packages/GFL_Castling/weapons/grenade_scarecrow.projectile
+++ b/packages/GFL_Castling/weapons/grenade_scarecrow.projectile
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <projectile class="grenade" name="" key="grenade_scarecrow.projectile" slot="1" radius="0.25" pulldown_in_air="50">
 
-    <result class="blast" radius="10.0" damage="10.0" push="0.8" decal="1" character_state="death" faction_compare="not_equal" />
+    <result class="spawn" instance_class="projectile" instance_key="blast_snipe_airburst.projectile" min_amount="8" max_amount="8" make_vehicle_hit_sound="0" offset="0 0.5 0" position_spread="0 0" direction_spread="0.0 0.0" />
     <trigger class="impact"/>
     <rotation class="random" />
     <model mesh_filename="" />


### PR DESCRIPTION
纯盲写 没测试

改动内容：
1. FF稻草人数值少量加强，补充[暗影捕食]技能（不明白为什么除了脚本都写完了就是没做） #98 
2. FF炼金术士1模式调回全自动（半自动纯搞人的，按得比猎手1模式难受多了），2模式不变
3. FF法官提高视野，略微改善精度
4. FF代理人射弹push减小（邪恶lap写个这么大的数震我屏幕太坏了）