### PR TITLE
[fix] 在玩家复活后阻止mg4mod3技能后两轮扫射的执行 and ump45mod3的倒地效果执行

### DIFF
--- a/packages/GFL_Castling/scripts/trackers/GFLtask.as
+++ b/packages/GFL_Castling/scripts/trackers/GFLtask.as
@@ -946,6 +946,8 @@ class strafe_task_30mm : event_call_task {
 		m_excute_time++;
 		m_timeLeft_internal = m_time_internal;
 
+		const XmlElement@ character = getCharacterInfo(m_metagame,m_character_id);
+		if(character is null){m_end = true;return;}
 		insertCommonStrike(m_character_id,m_faction_id,m_airstrike_key,m_pos1,m_pos2);
 		m_pos1 = m_pos1.add(getMultiplicationVector(strike_vector,Vector3(strike_didis,0,strike_didis)));
 		m_pos1 = m_pos1.add(Vector3(0,-20*(sqrt(float(1/m_excute_Limit)*m_excute_time)),0));
@@ -986,6 +988,8 @@ class strafe_task_15mm_mg151 : event_call_task {
 		m_excute_time++;
 		m_timeLeft_internal = m_time_internal;
 
+		const XmlElement@ character = getCharacterInfo(m_metagame,m_character_id);
+		if(character is null){m_end = true;return;}
 		insertCommonStrike(m_character_id,m_faction_id,m_airstrike_key,m_pos1,m_pos2);
 		m_pos1 = m_pos1.add(getMultiplicationVector(strike_vector,Vector3(strike_didis,0,strike_didis)));
 		m_pos1 = m_pos1.add(Vector3(0,-20*(sqrt(float(1/m_excute_Limit)*m_excute_time)),0));

--- a/packages/GFL_Castling/scripts/trackers/event_system.as
+++ b/packages/GFL_Castling/scripts/trackers/event_system.as
@@ -210,6 +210,11 @@ void excuteSniperM200(GameMode@ metagame,GFL_event@ eventinfo){
 
 void excuteUMP45MOD3event(GameMode@ metagame,GFL_event@ eventinfo){
     eventinfo.m_time=3.0;
+    const XmlElement@ character = getCharacterInfo(metagame,eventinfo.m_characterId);
+	if(character is null){
+        eventinfo.m_enable=false;
+        return;
+    }
     CreateDirectProjectile(metagame,eventinfo.m_pos.add(Vector3(0,6,0)),eventinfo.m_pos.add(Vector3(0,6.1,0)),'ump45mod3_skill.projectile',eventinfo.m_characterId,eventinfo.m_factionid,10);
     eventinfo.m_phase++;
     if(eventinfo.m_phase>6){


### PR DESCRIPTION
给mg4mod3技能的后两轮（strafe_task_30mm）添加了角色存在性检验，以阻止玩家重生后技能仍然发动误伤队友；start没处理，小飞机飞来飞去无所谓

看了一下感觉第一轮来得早问题小，并且第一轮也给吃了有点怪，于是第一轮没管

顺便ump45mod3的倒地效果也做了检查