### PR TITLE
[feat] 添加图鉴中缺失的人形的检查功能

### DIFF
--- a/packages/GFL_Castling/languages/cn/GFL_alltext.xml
+++ b/packages/GFL_Castling/languages/cn/GFL_alltext.xml
@@ -2135,6 +2135,8 @@
     <text key="Logger Mask Auto" text="您的图鉴中没有该人形，已自动帮您录入图鉴"/>
     <text key="Logger info query" text="已收集战术人形：&#37;doll_number/&#37;all_dollnum位&#37;PS
 您的战术人形收集率为&#37;doll_collect%"/>
+    <text key="Logger missing query" text="未收集的战术人形摘录：&#37;list"/>
+    <text key="Logger missing none" text="恭喜，您已收集全部战术人形！"/>
     <text key="Dev info query" text="当前研发点数量:&#37;dev_point
 生涯研发点获得数量:&#37;life_dev_point"/>
     <text key="Waifu info query" text="人形:&#37;waifu_name

--- a/packages/GFL_Castling/languages/en/GFL_alltext.xml
+++ b/packages/GFL_Castling/languages/en/GFL_alltext.xml
@@ -19,6 +19,8 @@
 	<text key="Logger Mask Auto" text="Auto logger successful"/>
 	<text key="Logger info query" text="You have&#37;doll_number/&#37;all_dollnum&#37;PS
 Doll ratio:&#37;doll_collect%"/>	
+	<text key="Logger missing query" text="Extracts of uncollected T-Dolls: &#37;list"/>
+    <text key="Logger missing none" text="Congratulations, you have collected all T-Dolls!"/>
 	<text key="Dev info query" text="Current Dev Point:&#37;dev_point
 Life Dev Point Gained:&#37;life_dev_point"/>
 	<text key="craft progression start" text="Confirmed recoverable T-Doll list. Please input /craft #skin_index #type to recover T-Doll." />

--- a/packages/GFL_Castling/scripts/core/save_system.as
+++ b/packages/GFL_Castling/scripts/core/save_system.as
@@ -9,6 +9,7 @@
 #include "GFLhelpers.as"
 #include "GFLplayerlist.as"
 #include "GFLparameters.as"
+#include "girl_index.as"
 
 // sid = sid
 // 记录玩家武器数据 使用<weapon key="武器key">形式存储在<weapons>元素下
@@ -790,6 +791,44 @@ class Save_System : Tracker {
             string collect = formatFloat(collect_value,"",0,2);
             a["%doll_collect"] = "" + collect;
             notify(m_metagame, "Logger info query", a, "misc", player_id, false, "", 1.0);
+        }
+        if(checkCommand(message,"missing")){
+            GFL_playerInfo@ playerInfo = getPlayerInfoFromList(p_name);            
+            if (playerInfo.getPlayerName() == default_string ) return;
+            string profile_hash = playerInfo.getHash();
+            string sid = playerInfo.getSid();
+            int player_id = playerInfo.getPlayerPid();
+            player_data newdata = PlayerProfileLoad(readFile(m_metagame,p_name,profile_hash)); 
+            const XmlElement@ player = getPlayerInfo(m_metagame,player_id);
+            if (player is null) return;
+            int cId = player.getIntAttribute("character_id");
+            dictionary player_weapon_set;
+            for (uint i = 0; i < newdata.m_weapons.length(); i++){
+                player_weapon_set.set(newdata.m_weapons[i], true);
+            }
+            array<string> all_keys = reverse_tdoll_complex_index.getKeys();
+            array<string> result;
+            uint start = rand(0, all_keys.length() - 1);
+            for (uint i = 0; i < all_keys.length(); i++){
+                uint idx = (start + i) % all_keys.length();
+                string key = all_keys[idx];
+                if (!player_weapon_set.exists(key)){
+                    result.insertLast(key);
+                    if (result.length() >= 3) break;
+                }
+            }
+            if (result.length() > 0){
+                dictionary a;
+                string list = "";
+                for (uint i = 0; i < result.length(); i++){
+                    list += "\n" + result[i];
+                }
+                a["%list"] = list;
+                notify(m_metagame, "Logger missing query", a, "misc", player_id, false, "", 1.0);
+            }
+            else{
+                notify(m_metagame, "Logger missing none", dictionary(), "misc", player_id, false, "", 1.0);
+            }
         }
         if(checkCommand(message,"balance")){
             GFL_playerInfo@ playerInfo = getPlayerInfoFromList(p_name);


### PR DESCRIPTION
添加一个新指令`/missing`，用来检查并列出至多3把个人收集图鉴中缺失的武器key
目前的逻辑是随机起点顺序找到至多3把不在图鉴中的武器key就返回，缺失数量小于3时等效于全表遍历，无缺失时返回另一句话
<img width="603" height="385" alt="image" src="https://github.com/user-attachments/assets/ec25282c-d79a-4496-a2e8-e2995ca8ce70" />

已知问题：如果收集数量很多，缺失数量很少，遍历所需的时间会相应变长，但我不好测试这个东西的性能

（话说回来，之前没有`#include "girl_index.as"`究竟是怎么调用里面的变量和函数的）