### PR TITLE
[fix] 为tac50技能添加最长约90秒执行时间检查

### DIFF
--- a/packages/GFL_Castling/scripts/trackers/GFLtask.as
+++ b/packages/GFL_Castling/scripts/trackers/GFLtask.as
@@ -2399,12 +2399,16 @@ class DelayGPSScanRequest : Task{
 
 class Tac50_Maple_Sniper_Drone : DelaySkill {
 	protected array<const XmlElement@> affectedCharacter;
+	protected int m_tickCount;
+	protected int m_tickLimit;
 
 	void start(){
 		m_timeLeft=m_time;
 		m_timeLeft_internal = 0;
 		this.setExcuteLimit(10);
-		this.setInternal(5.0);		
+		this.setInternal(5.0);
+		m_tickCount = 0;
+		m_tickLimit = 18; // 90s CD / 5s Internal
 	}
 
 	Tac50_Maple_Sniper_Drone(GameMode@ metagame, float time, int cId,int fId){
@@ -2415,7 +2419,9 @@ class Tac50_Maple_Sniper_Drone : DelaySkill {
 		if(m_timeLeft >= 0){m_timeLeft -= time;return;}
 		if (m_timeLeft_internal >= 0){m_timeLeft_internal -= time;return;}
 		if (m_excute_time >= m_excute_Limit){m_end = true;return;}
+		if (m_tickCount >= m_tickLimit){m_end = true;return;}
 		m_timeLeft_internal = m_time_internal;
+		m_tickCount++;
 
 		const XmlElement@ character_tac50 = getCharacterInfo(m_metagame, m_character_id);
 		if (checkCharacterDead(character_tac50))


### PR DESCRIPTION
这么做是因为技能冷却是90秒，然而现在的写法只要10发不打完就能续一辈子，因此甚至可以叠技能

加了一个检查，只允许update主体执行18次，超时之后无人机没电了下线（确信

说实话改这玩意是因为我手痒想写空爆玩了先来刺探圣意来的 但我显然不该把这俩放一个PR里）