### PR TITLE
[feat] tac50_only草稿

### DIFF
--- a/packages/GFL_Castling/factions/gk.models
+++ b/packages/GFL_Castling/factions/gk.models
@@ -813,13 +813,19 @@
         <requirement class="weapon" key="gkw_tac50.weapon" slot="0" />
     </model>
     <model filename="gkd_rf_tac50.xml">
-        <requirement class="weapon" key="gkw_tac50_only_ap.weapon" slot="0" />
+        <requirement class="weapon" key="gkw_tac50_only.weapon" slot="0" />
     </model>
     <model filename="gkd_rf_tac50.xml">
-        <requirement class="weapon" key="gkw_tac50_only_he.weapon" slot="0" />
+        <requirement class="weapon" key="gkw_tac50_only_skill.weapon" slot="0" />
     </model>
     <model filename="gkd_rf_tac50_2602.xml">
         <requirement class="weapon" key="gkw_tac50_2602.weapon" slot="0" />
+    </model>
+    <model filename="gkd_rf_tac50_2602.xml">
+        <requirement class="weapon" key="gkw_tac50_2602_only.weapon" slot="0" />
+    </model>
+    <model filename="gkd_rf_tac50_2602.xml">
+        <requirement class="weapon" key="gkw_tac50_2602_only_skill.weapon" slot="0" />
     </model>
     <model filename="gkd_ar_qbz191.xml">
         <requirement class="weapon" key="gkw_qbz191.weapon" slot="0" />

--- a/packages/GFL_Castling/factions/gk.resources
+++ b/packages/GFL_Castling/factions/gk.resources
@@ -492,8 +492,10 @@
 
     <weapon key="gkw_tac50.weapon" />
     <weapon key="gkw_tac50_2602.weapon" />
-    <weapon key="gkw_tac50_only_ap.weapon" />
-    <weapon key="gkw_tac50_only_he.weapon" />
+    <weapon key="gkw_tac50_only.weapon" />
+    <weapon key="gkw_tac50_only_skill.weapon" />
+    <weapon key="gkw_tac50_2602_only.weapon" />
+    <weapon key="gkw_tac50_2602_only_skill.weapon" />
 
     <weapon key="gkw_vsk94.weapon" />
     <weapon key="gkw_vsk94_5301.weapon" />

--- a/packages/GFL_Castling/languages/cn/GFL_alltext.xml
+++ b/packages/GFL_Castling/languages/cn/GFL_alltext.xml
@@ -1002,6 +1002,7 @@
     <text key="OTs-12 Tiss" text="OTs-12“紫杉树”突击步枪" />
     <text key="S.W. Model 327 Revolver" text="史密斯威森Model 327左轮手枪" />
     <text key="McMillan TAC-50" text="麦克米兰TAC-50狙击步枪"/>
+    <text key="McMillan TAC-50 A1-R2" text="麦克米兰TAC-50 A1-R2狙击步枪-[液压系统后托]"/>
     <text key="CETME Ameli MG82" text="赛特迈 阿梅利MG82通用机枪" />
     <text key="CETME Ameli MG82-[Lock and Load N]" text="赛特迈 阿梅利MG82通用机枪-[蓄势待发N]" />
     <text key="6P62" text="6P62战斗步枪" />
@@ -1316,6 +1317,7 @@
     <text key="M4 SOPMOD II-[Birdsong in the Woods]" text="M4 SOPMOD II-[深林鸣音]"/>
     <text key="M4 SOPMOD II-[Cocktail Party Exterminator]" text="M4 SOPMOD II-[酒席的扫荡者]"/>
     <text key="McMillan TAC-50-[Elven Demon Huntress]" text="麦克米兰TAC-50狙击步枪-[精灵狙魔士]"/>
+    <text key="McMillan TAC-50 A1-R2-[Elven Demon Huntress]" text="麦克米兰TAC-50 A1-R2狙击步枪-[液压系统后托]-[精灵狙魔士]"/>
     <text key="Maschinenpistole 40-[Thumbelina]" text="Maschinenpistole 40-[拇指公主]"/>
     <text key="Maschinenpistole 40-[Champagne of Spades]" text="Maschinenpistole 40-[黑桃香槟]"/>
     <text key="6P62-[6P62's Offer]" text="6P62战斗步枪-[6P62的Offer]" />

--- a/packages/GFL_Castling/scripts/core/command_skill_info.as
+++ b/packages/GFL_Castling/scripts/core/command_skill_info.as
@@ -521,6 +521,10 @@ dictionary commandSkillIndex = {
 
         {"gkw_tac50.weapon",82},
         {"gkw_tac50_2602.weapon",82},
+        {"gkw_tac50_only.weapon",82},
+        {"gkw_tac50_only_skill.weapon",82},
+        {"gkw_tac50_2602_only.weapon",82},
+        {"gkw_tac50_2602_only_skill.weapon",82},
 
         {"gkw_obrmod3.weapon",83},
         {"gkw_obrmod3_skill.weapon",83},

--- a/packages/GFL_Castling/scripts/core/girl_index.as
+++ b/packages/GFL_Castling/scripts/core/girl_index.as
@@ -828,7 +828,8 @@ dictionary tdoll_complex_index = {
 
     {modded_key(222).toString(),"gkw_tac50.weapon"},
     {modded_key(222,2602).toString(),"gkw_tac50_2602.weapon"},
-    {modded_key(222,0,"only").toString(),"gkw_tac50_only_ap.weapon"},
+    {modded_key(222,0,"only").toString(),"gkw_tac50_only.weapon"},
+    {modded_key(222,2602,"only").toString(),"gkw_tac50_2602_only.weapon"},
     
     {modded_key(223).toString(),"gkw_modell.weapon"},
 
@@ -1540,6 +1541,10 @@ array<string> gk_weapon_rf_list = {
     "gkw_ksvkmod3_7807_skill.weapon",
     "gkw_tac50.weapon",
     "gkw_tac50_2602.weapon",
+    "gkw_tac50_only.weapon",
+    // "gkw_tac50_only_skill.weapon",
+    "gkw_tac50_2602_only.weapon",
+    // "gkw_tac50_2602_only_skill.weapon",
     "gkw_gepardm1.weapon",
     "gkw_gepardm1_4006.weapon",
     "gkw_gepardm1mod3.weapon",

--- a/packages/GFL_Castling/scripts/delivery/item_delivery_configurator_invasion.as
+++ b/packages/GFL_Castling/scripts/delivery/item_delivery_configurator_invasion.as
@@ -207,7 +207,7 @@ class ItemDeliveryConfiguratorInvasion : ItemDeliveryConfigurator {
 		ScoredResource("upgrade_cso.carry_item", "carry_item", 0.1f),
 		ScoredResource("upgrade_type4.carry_item", "carry_item", 0.1f),
 		ScoredResource("upgrade_sr3mp.carry_item", "carry_item", 0.1f),
-		// ScoredResource("upgrade_tac50.carry_item", "carry_item", 0.1f),
+		ScoredResource("upgrade_tac50.carry_item", "carry_item", 0.1f),
 		ScoredResource("upgrade_usas12.carry_item", "carry_item", 0.1f),
 
 		

--- a/packages/GFL_Castling/scripts/trackers/ItemDropEvent.as
+++ b/packages/GFL_Castling/scripts/trackers/ItemDropEvent.as
@@ -587,7 +587,13 @@ class ItemDropEvent : Tracker {
                     }
                     else if ( (checkQueue(pId,"usas12") || checkQueue(pId,"masterkey") ) && (itemKey=="gkw_usas12_2704.weapon" || itemKey=="gkw_usas12_2704_skill.weapon")){
                         giveDigimindItem(cId, pId, "gkw_usas12_2704_only.weapon", "usas12");
-                    }                                        
+                    }
+                    else if ( (checkQueue(pId,"tac50") || checkQueue(pId,"masterkey") ) && (itemKey=="gkw_tac50.weapon")){
+                        giveDigimindItem(cId, pId, "gkw_tac50_only.weapon", "tac50");
+                    }
+                    else if ( (checkQueue(pId,"tac50") || checkQueue(pId,"masterkey") ) && (itemKey=="gkw_tac50_2602.weapon")){
+                        giveDigimindItem(cId, pId, "gkw_tac50_2602_only.weapon", "tac50");
+                    }
                     break;
                 }
             }

--- a/packages/GFL_Castling/weapons/gk_weapons.xml
+++ b/packages/GFL_Castling/weapons/gk_weapons.xml
@@ -434,7 +434,8 @@
 <weapon file="gkw_189_sg_12g_usas12_only_2704_SKIN.weapon"/>
 <weapon file="gkw_222_rf_50bmg_tac50.weapon"/>
 <weapon file="gkw_222_rf_50bmg_tac50_2602_SKIN.weapon" />
-<!-- <weapon file="gkw_222_rf_50bmg_tac50_only.weapon" /> -->
+<weapon file="gkw_222_rf_50bmg_tac50_only.weapon" />
+<weapon file="gkw_222_rf_50bmg_tac50_2602_SKIN_only.weapon" />
 <weapon file="gkw_361_ar_58x42_qbz191.weapon"/>
 <weapon file="gkw_361_ar_58x42_qbz191_7702_SKIN.weapon"/>
 <weapon file="gkw_361_ar_58x42_qbz191_10101_SKIN.weapon"/>

--- a/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN.weapon
+++ b/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN.weapon
@@ -30,9 +30,6 @@
 	<animation key="reload" animation_key="reloading, magazine rifle 1.8" />
     <animation state_key="recoil" animation_key="recoil1, big" />
     <animation key="recoil" stance_key="prone" animation_key="recoil1, big, prone" />
-    <animation state_key="running" animation_key="running, line infantry" />
-    <animation state_key="walking" animation_key="walking, line infantry" />
-    <animation state_key="walking_backwards" animation_key="walking, line infantry" />	
 	<animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
 	<animation state_key="stabbing" animation_key="melee, quick knife" />
 	<animation state_key="stabbing" animation_key="pistol whip 3" />

--- a/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN.weapon
+++ b/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN.weapon
@@ -8,7 +8,7 @@
 	sustained_fire_grow_step="3.0" 
 	sustained_fire_diminish_rate="1.5" 
 	magazine_size="5" 
-	can_shoot_standing="1" 
+	can_shoot_standing="0" 
 	can_shoot_crouching="1"
 	can_shoot_prone="1"
 	suppressed="0" 
@@ -30,6 +30,9 @@
 	<animation key="reload" animation_key="reloading, magazine rifle 1.8" />
     <animation state_key="recoil" animation_key="recoil1, big" />
     <animation key="recoil" stance_key="prone" animation_key="recoil1, big, prone" />
+	<animation state_key="running" animation_key="running, line infantry" />
+    <animation state_key="walking" animation_key="walking, line infantry" />
+    <animation state_key="walking_backwards" animation_key="walking, line infantry" />
 	<animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
 	<animation state_key="stabbing" animation_key="melee, quick knife" />
 	<animation state_key="stabbing" animation_key="pistol whip 3" />

--- a/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN_only.weapon
+++ b/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN_only.weapon
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <weapons>
-<weapon file="designated_marksman_rifle.animation_base" key="gkw_tac50_only.weapon">
+<weapon file="designated_marksman_rifle.animation_base" key="gkw_tac50_2602_only.weapon">
 	<tag name="rifle" />
 	<!--Weapon specifications-->
 	<specification 
@@ -13,7 +13,7 @@
 	can_shoot_crouching="1"
 	can_shoot_prone="1"
 	suppressed="0" 
-	name="McMillan TAC-50 A1-R2" 
+	name="McMillan TAC-50 A1-R2-[Elven Demon Huntress]" 
 	class="2"
 	reload_one_at_a_time="0" 
 	sight_range_modifier="2.25" 
@@ -24,7 +24,8 @@
 	projectiles_per_shot="1"
      />
 	<inventory encumbrance="35.0" buy_price="500.0" sell_price="500.0" />
-	<next_in_chain key="gkw_tac50_only_skill.weapon" share_ammo="1" />
+	<next_in_chain key="gkw_tac50_2602_only_skill.weapon" share_ammo="1" />
+	<commonness value="0" in_stock="0" />
 	<!--Animations-->
 	<animation state_key="next_in_chain_in" animation_key="switch fire mode"/>
 	<animation key="cycle" animation_key="Brifle action"/>
@@ -45,8 +46,8 @@
 	<sound class="impact" fileref="rifle_drop.wav" />
 	<sound key="dry_fire" fileref="dryfire_atrf.wav" pitch_variety="0.05" volume="1.0" />
 	<!--Model, Icon, Cost-->
-	<model filename="gkw_rf_tac50c_n.xml" />
-	<hud_icon filename="gkw_tac50_only.png" />
+	<model filename="gkw_rf_tac50_2602.xml" />
+	<hud_icon filename="gkw_tac50_2602.png" />
 	<!--Ballistics-->
 	<weak_hand_hold offset="0.3" />
 	<projectile file="at_rf_spawn.projectile" pulldown_in_air="4" can_be_detected_by_footmen="1" can_be_detected_by_driver="1" can_be_disarmed="0" radius="0.7">
@@ -54,8 +55,17 @@
 		<trigger class="impact"/>
 		<rotation class="motion" />
 		<collision class="sticky" />
+		<effect class="result" key="character" ref="center_area_lighting" />  
+		<effect class="result" key="character" ref="lens_circle_enlarge" />  
+		<effect class="result" key="character" ref="v_type_impact_flare" />  
+		<effect class="result" key="character" ref="lens_flare_01" />  
+		<effect class="result" key="character" ref="lens_circle" />  		
+		<effect class="result" key="vehicle" copy="character" />
+		<effect class="result" key="static_object" copy="character" />
+		<effect class="result" key="terrain" copy="character" />  
+		<effect class="result" key="other" copy="character"/>		
 	</projectile>
-	<effect class="muzzle" ref="at_bullet_smoke_trail" lighting="0"/> 
+    <effect class="muzzle" ref="at_bullet_aiming_trail" lighting="0"/> 
 	<effect class="muzzle" ref="general_weapon_muzzle_crossfire" lighting="0"/> 
 	<effect class="muzzle" ref="general_weapon_muzzle_crossfire_smoke" lighting="0"/> 
 	<effect class="muzzle" ref="ejection_50BMG" />
@@ -71,7 +81,7 @@
 	<modifier class="detectability" value="-0.1"/>
 	<modifier class="speed" value="-0.15" />
 </weapon>
-<weapon file="designated_marksman_rifle.animation_base" key="gkw_tac50_only_skill.weapon">
+<weapon file="designated_marksman_rifle.animation_base" key="gkw_tac50_2602_only_skill.weapon">
 	<tag name="rifle" />
 	<!--Weapon specifications-->
 	<specification 
@@ -84,7 +94,7 @@
 	can_shoot_crouching="1"
 	can_shoot_prone="1"
 	suppressed="0" 
-	name="McMillan TAC-50 A1-R2" 
+	name="McMillan TAC-50 A1-R2-[Elven Demon Huntress]" 
 	class="2"
 	reload_one_at_a_time="0" 
 	sight_range_modifier="2.25" 
@@ -95,7 +105,7 @@
 	projectiles_per_shot="1"
      />
 	<inventory encumbrance="35.0" buy_price="500.0" sell_price="500.0" />
-	<next_in_chain key="gkw_tac50_only.weapon" share_ammo="1" />
+	<next_in_chain key="gkw_tac50_2602_only.weapon" share_ammo="1" />
 	<!--Animations-->
 	<animation state_key="next_in_chain_in" animation_key="switch fire mode"/>
 	<animation key="cycle" animation_key="Brifle action"/>
@@ -116,8 +126,8 @@
 	<sound class="impact" fileref="rifle_drop.wav" />
 	<sound key="dry_fire" fileref="dryfire_atrf.wav" pitch_variety="0.05" volume="1.0" />
 	<!--Model, Icon, Cost-->
-	<model filename="gkw_rf_tac50c_n.xml" />
-	<hud_icon filename="gkw_tac50_only.png" />
+	<model filename="gkw_rf_tac50_2602.xml" />
+	<hud_icon filename="gkw_tac50_2602.png" />
 	<!--Ballistics-->
 	<weak_hand_hold offset="0.3" />
 	<ballistics curve_height="0.2" near_far_distance="0.0" speed_estimation_near="320.0" speed_estimation_far="320.0" max_speed="320.0" randomness="0.0" tweak_factor="7.0"/>
@@ -126,6 +136,15 @@
 		<trigger class="time" time_to_live="0.25"/>
 		<rotation class="motion" />
 		<collision class="impact" />
+		<effect class="result" key="character" ref="center_area_lighting" />  
+		<effect class="result" key="character" ref="lens_circle_enlarge" />  
+		<effect class="result" key="character" ref="v_type_impact_flare" />  
+		<effect class="result" key="character" ref="lens_flare_01" />  
+		<effect class="result" key="character" ref="lens_circle" />  		
+		<effect class="result" key="vehicle" copy="character" />
+		<effect class="result" key="static_object" copy="character" />
+		<effect class="result" key="terrain" copy="character" />  
+		<effect class="result" key="other" copy="character"/>
 	</projectile>
 	<effect class="muzzle" ref="general_weapon_muzzle_crossfire" lighting="0"/> 
 	<effect class="muzzle" ref="general_weapon_muzzle_crossfire_smoke" lighting="0"/> 

--- a/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN_only.weapon
+++ b/packages/GFL_Castling/weapons/gkw_222_rf_50bmg_tac50_2602_SKIN_only.weapon
@@ -9,7 +9,7 @@
 	sustained_fire_grow_step="3.0" 
 	sustained_fire_diminish_rate="1.5" 
 	magazine_size="5" 
-	can_shoot_standing="1" 
+	can_shoot_standing="0" 
 	can_shoot_crouching="1"
 	can_shoot_prone="1"
 	suppressed="0" 
@@ -33,6 +33,9 @@
 	<animation key="reload" animation_key="reloading, magazine rifle 1.8" />
     <animation state_key="recoil" animation_key="recoil1, big" />
     <animation key="recoil" stance_key="prone" animation_key="recoil1, big, prone" />
+	<animation state_key="running" animation_key="running, line infantry" />
+    <animation state_key="walking" animation_key="walking, line infantry" />
+    <animation state_key="walking_backwards" animation_key="walking, line infantry" />
 	<animation state_key="celebrate_shoot" animation_key="celebrating, shooting" />
 	<animation state_key="stabbing" animation_key="melee, quick knife" />
 	<animation state_key="stabbing" animation_key="pistol whip 3" />


### PR DESCRIPTION
直接复用当时给rt20写的空爆弹版本来的

1模式 与tac50几乎一致，改善了stance_accuracy_rate
2模式 定点空爆，33.3RPM，每发1.1b*20，散布最大值显著增大，并且没给战术点加成

另外移除了2602_SKIN的站姿射击，因为神秘3个动作会卡移动站姿射击（帅气的代价是便利性）

我说实话我控制不住强度，我觉得现在这样还是很变态，但是我想玩于是写了，你不要也罢，顶多我emo几秒钟（）

无论如何请处理一下 PR #145 