### PR TITLE
[fix] 尝试修复m16蝎甲兽支援不刷人问题

### DIFF
--- a/packages/GFL_Castling/languages/cn/GFL_alltext.xml
+++ b/packages/GFL_Castling/languages/cn/GFL_alltext.xml
@@ -26,7 +26,7 @@
     <text key="Echelon enter the battlefield" text="场地清空，开始投放" />
     <text key="Tactical Doll repair kit" text="人形修复工具包" />
     <text key="Battlefield armor repair kit" text="战地修复组件" />
-    <text key="CZ75 AXE" text="CZ-75的战术飞斧" />    
+    <text key="CZ75 AXE" text="CZ-75的战术飞斧" />
     <text key="88type Cluster grenade" text="88式重型手榴弹" />
     <text key="RGD-5 Offensive grenade" text="RGD-5进攻型手榴弹" />
     <text key="M67 defence grenade" text="M67防御型手榴弹" />
@@ -60,18 +60,18 @@
     <text key="Fairy Command:Reinforcement--Anti Rain" text="妖精指令:增援--Anti Rain小队[进攻型]" />
     <text key="Fairy Command:Reinforcement--Medic" text="妖精指令:增援--创伤小组[进攻型]" />
     <text key="Fairy Command:Reinforcement--HVY" text="妖精指令:增援--重装小队[防御型]" />
-    <text key="Fairy Command:Reinforcement--MG/SG" text="妖精指令:增援--机霰队[防御型]" />    
+    <text key="Fairy Command:Reinforcement--MG/SG" text="妖精指令:增援--机霰队[防御型]" />
     <text key="Fairy Command:Reinforcement--Team Negev" text="妖精指令:增援--内格夫小队[防御型]" />
 
     <text key="Fairy Command:Reinforcement--Day Break" text="妖精指令:增援--曙光小队[进攻型]" />
     <text key="Fairy Command:Reinforcement--Palette" text="妖精指令:增援--调色板小队[进攻型]" />
     <text key="Fairy Command:Reinforcement--Manticore?[Cost 20 TP]" text="妖精指令:增援--强无敌?[进攻型][消耗20战术点]" />
 
-    
+
     <text key="Fairy Command:Mine" text="妖精指令:布雷妖精" />
     <text key="Fairy Command:Origin -- An End To Hesitation" text="妖精指令:原型妖精 -- 彷徨终结[消耗1000战术点]" />
 
-    <text key="Parachute Fairy" text="空降妖精"/> 
+    <text key="Parachute Fairy" text="空降妖精"/>
     <text key="Type 25 disposable rocket launcher" text="25式便携火箭筒" />
     <text key="Egor Lebedev" text="叶戈尔画像" />
     <text key="Construction Fairy:Bunker" text="工事妖精:碉堡"/>
@@ -83,12 +83,12 @@
     <text key="New Year Giftbox" text='"福袋女神的微笑"'/>
     <text key="Golyat" text="便携式歌莉娅"/>
     <text key="FGM-148 Javelin" text="FGM-148“标枪”反坦克导弹"/>
-    <text key="HellFire Incinerator" text="“地狱火燃烧区域"/> 
+    <text key="HellFire Incinerator" text="“地狱火燃烧区域"/>
     <text key="flamethrower" text="火焰"/>
     <text key="flame grenade" text="燃烧弹"/>
-    <text key="MON-50 Anti-Person Mine" text="MON-50反人员地雷"/> 
-    <text key="Mon-200" text="Mon-200定向反步兵地雷"/> 
-    <text key="explosive bolt" text="高爆弩箭"/> 
+    <text key="MON-50 Anti-Person Mine" text="MON-50反人员地雷"/>
+    <text key="Mon-200" text="Mon-200定向反步兵地雷"/>
+    <text key="explosive bolt" text="高爆弩箭"/>
     <text key="Fire Control Component" text="新型火控元件"/>
     <text key="T-Doll Contract" text="人形制造契约"/>
     <text key="T-Doll Contract [AR Formula]" text="人形制造契约-[AR公式]"/>
@@ -103,12 +103,12 @@
     <text key="Singularity Supply Box" text="塌缩点物资箱"/>
     <text key="Arctic Warfare Supply Box" text="失温症物资箱"/>
 
-    
+
     <text key="Request IOP Supply" text="投放IOP安全贮藏箱"/>
     <text key="IOP Stash Chest" text="IOP安全箱"/>
     <text key="IOP Supply Chest" text="IOP补给箱"/>
     <text key="IOP HVY Chest" text="IOP重装工事补给箱"/>
-    <text key="T6 Equipment Shop" text="Tier 6 装备商店"/>    
+    <text key="T6 Equipment Shop" text="Tier 6 装备商店"/>
     <text key="IOP Supply Deploy" text="IOP补给箱部署包"/>
     <text key="IOP HVY Deploy" text="IOP重装工事补给箱部署包"/>
     <text key="Tough Battle Supply Box" text="绝境歼殛物资箱"/>
@@ -131,18 +131,18 @@
     <text key="costume, santa, destroyed" text="圣诞叶套装-超限!-" />
     <text key="Eleanor" text="“埃莉诺”涅托特制高性能护甲" />
     <text key="Standard SF Assault Exo" text="铁血工造标准突击外骨骼" />
-    <text key="Code:Cyclops" text="Code:Cyclops “独眼巨人”基础防护装甲" />    
+    <text key="Code:Cyclops" text="Code:Cyclops “独眼巨人”基础防护装甲" />
     <text key="Abandoned Car 1" text="被遗弃的平民车辆"/>
     <text key="Abandoned Car 2" text="被遗弃的平民车辆"/>
     <text key="Abandoned Car 3" text="被遗弃的平民车辆"/>
     <text key="Abandoned Sports" text="被遗弃的跑车"/>
     <text key="Abandoned pickup Truck" text="被遗弃的皮卡"/>
-    <text key="Abandoned Van Car" text="被遗弃的厢型车"/>    
+    <text key="Abandoned Van Car" text="被遗弃的厢型车"/>
     <text key="Target-Punch it！" text="靶机-打他！"/>
     <text key="vehicle" text="???"/>
-    <text key="Medusina" text="美杜斯纳"/> 
-    <text key="Postmodern Warhouse" text="后现代军马"/> 
-    <text key="Legend" text="传奇"/> 
+    <text key="Medusina" text="美杜斯纳"/>
+    <text key="Postmodern Warhouse" text="后现代军马"/>
+    <text key="Legend" text="传奇"/>
 
     <text key="G&amp;K Skin GiftBox - Halloween Theme" text="G&amp;K 主题皮肤礼盒 - 万圣"/>
     <text key="G&amp;K Skin GiftBox - Spring Festival Theme" text="G&amp;K 主题皮肤礼盒 - 春节"/>
@@ -150,8 +150,8 @@
     <text key="G&amp;K Skin GiftBox - Santa Theme" text="G&amp;K 主题皮肤礼盒 - 圣诞"/>
     <text key="G&amp;K Skin GiftBox - White Day Theme" text="G&amp;K 主题皮肤礼盒 - 白情"/>
 
-    
-    <text key="Universal Component Package" text="通用组件包 [适用于所有烙印升级]"/> 
+
+    <text key="Universal Component Package" text="通用组件包 [适用于所有烙印升级]"/>
     <text key="Fire Selector" text="快慢机扳机组 [FN-49]"/>
     <text key="M2 Bipod" text="M2两脚架 [M14]"/>
     <text key="12GA Flechette Shells" text="12GA飞镖弹 [温彻斯特Model 1897霰弹枪]"/>
@@ -177,7 +177,7 @@
     <text key="Polymer Rounds Drum" text="聚合物弹鼓 [USAS-12]"/>
     <text key="Hydraulic Recoil Mitigation System" text="液压系统后托 [麦克米兰TAC-50狙击步枪]"/>
 
-    
+
 
     <text key="AEK999 spawn" text="AEK-999的摩托"/>
     <text key="Wheelchair spawn" text="双人协同型高机动作战轮椅"/>
@@ -188,27 +188,27 @@
 
     <text key="Barrier Fairy" text="立盾妖精" />
     <text key="Armor Fortification" text="护甲加固" />
-    
-    <text key="Fury Fairy" text="暴怒妖精"/>    
-    <text key="Gunship support" text="很生气的炮艇支援"/>    
-    <text key="Confirm, checking gunship status" text="确认请求，正在检查炮艇机状态"/>    
-    <text key="Gunship status confirmed" text="炮艇机怒气值确认完毕"/>    
+
+    <text key="Fury Fairy" text="暴怒妖精"/>
+    <text key="Gunship support" text="很生气的炮艇支援"/>
+    <text key="Confirm, checking gunship status" text="确认请求，正在检查炮艇机状态"/>
+    <text key="Gunship status confirmed" text="炮艇机怒气值确认完毕"/>
 
     <text key="Warrior Fairy" text="勇士妖精"/>
     <text key="Cruise missile" text="超勇的武直支援"/>
-    <text key="Confirm, checking Helicopter status" text="确认请求，正在检查攻击直升机状态"/>    
+    <text key="Confirm, checking Helicopter status" text="确认请求，正在检查攻击直升机状态"/>
     <text key="Helicopter status confirmed" text="攻击直升机各参数确认完毕"/>
 
     <text key="Snipe Fairy" text="狙击妖精"/>
-    <text key="Snipe Fairy[15 Points]" text="狙击妖精[消耗15战术点]"/>    
-    <text key="Snipe Command" text="狙击指令"/>    
-    <text key="Confirm, checking Snipe UAV status" text="确认请求，正在检查狙击UAV状态"/>    
-    <text key="UAV status confirmed" text="UAV状态确认完毕"/>    
+    <text key="Snipe Fairy[15 Points]" text="狙击妖精[消耗15战术点]"/>
+    <text key="Snipe Command" text="狙击指令"/>
+    <text key="Confirm, checking Snipe UAV status" text="确认请求，正在检查狙击UAV状态"/>
+    <text key="UAV status confirmed" text="UAV状态确认完毕"/>
 
     <text key="Illumination Fairy" text="照明妖精"/>
     <text key="Illumination Fairy[10 Points]" text="照明妖精[消耗10战术点]"/>
-    <text key="Night Illumination" text="夜间照明"/>    
-    <text key="Confirm, checking recon UAV status" text="确认请求，正在检查侦察UAV状态"/>    
+    <text key="Night Illumination" text="夜间照明"/>
+    <text key="Confirm, checking recon UAV status" text="确认请求，正在检查侦察UAV状态"/>
 
     <text key="Reinforcement Fairy" text="增援妖精"/>
     <text key="8 Dummy with fire support" text="8台作战傀儡与火力压制"/>
@@ -222,7 +222,7 @@
     <text key="Bombardment Fairy" text="炮击妖精" />
     <text key="Bombard" text="炮击指令" />
     <text key="Data has been confirmed" text="确认，数据接收正常" />
-    
+
     <text key="Airstrike Fairy" text="空袭妖精" />
     <text key="Fatal Airstrike" text="致命空袭"/>
 
@@ -239,19 +239,19 @@
     <text key="manticore" text="蝎甲兽"/>
     <text key="Daybreak" text="曙光小队"/>
 
-    <text key="Tier 6 Equipment Ticket" text="Tier 6 装备兑换劵"/> 
-    <text key="Defence Fairy - Hesco Bastion" text="防御妖精 - Hesco防爆墙"/>    
-    <text key="Defence Fairy - Sandbag Cover" text="防御妖精 - 沙袋掩体"/>    
+    <text key="Tier 6 Equipment Ticket" text="Tier 6 装备兑换劵"/>
+    <text key="Defence Fairy - Hesco Bastion" text="防御妖精 - Hesco防爆墙"/>
+    <text key="Defence Fairy - Sandbag Cover" text="防御妖精 - 沙袋掩体"/>
     <text key="Fairy Command:Defence Fairy - Hesco Bastion" text="妖精指令:防御妖精 - Hesco防爆墙"/>
     <text key="Fairy Command:Defence Fairy - Sandbag Cover" text="妖精指令:防御妖精 - 沙袋掩体"/>
     <text key="Ogas Pulse Generator" text="OGAS脉冲发生器"/>
     <text key="shelter" text="掩体"/>
-    <text key="Bunker" text="碉堡"/>    
-    <text key="ELMO" text="ELMO 艾莫号"/>    
-    <text key="ELMO? Store" text="艾莫号?补给车"/>    
+    <text key="Bunker" text="碉堡"/>
+    <text key="ELMO" text="ELMO 艾莫号"/>
+    <text key="ELMO? Store" text="艾莫号?补给车"/>
     <text key="Mortar Truck - The Guer" text="迫击炮卡车 - 古尔号"/>
     <text key="Sidecar Motorcycle" text="边三轮机车"/>
-    
+
     <text key="Degeyter I" text="Degeyter I 狄盖特 - 武装气垫船"/>
     <text key="Pierre II" text="Pierre II 皮埃尔 - 自行榴弹平台"/>
     <text key="Chiara IV" text="Chiara IV 切尔拉 - 巡回式机枪车"/>
@@ -269,20 +269,20 @@
     <text key="Parachute Fairy-[ELMO? Store]" text="空降妖精-[艾莫号?补给车]"/>
     <text key="Parachute Fairy-[T-14 Armata][Cost 50 TP]" text="空降妖精-[T-14 阿玛塔主战坦克][需求50战术点]"/>
 
-    
+
     <text key="call_confirm" text="[确认当前选择]"/>
     <text key="call_dev" text="[研发当前选择分支]"/>
     <text key="call_update_alpha" text="[选择α分支]"/>
     <text key="call_update_beta" text="[选择β分支]"/>
     <text key="call_update_gamma" text="[选择γ分支]"/>
-    
+
 
     <text key="Tactic Fairy Tier 1" text="战术妖精 Tier 1" />
     <text key="Tactic Fairy Tier 2" text="战术妖精 Tier 2" />
     <text key="Tactic Fairy Tier 3" text="战术妖精 Tier 3" />
     <text key="Tactical Fairy System Initializing, standby." text="战术妖精系统初始化，等待中" />
     <text key="Tactic Fairy Console" text="战术妖精终端" />
-    
+
 
     <!-- 敌人单位翻译 -->
     <text key="SF-Manticore" text="强 无敌“蝎甲兽”机甲"/>
@@ -315,7 +315,7 @@
     <text key="S.F. Rider" text="S.F. Rider“骑手”全地形车"/>
     <text key="Jupiter Wheeled Assult Gun" text="“木星”轮式突击炮"/>
 
-    
+
 
     <text key="SF-Agent" text="SF-Agent “代理人”"/>
     <text key="SF-Alchemist" text="SF-Alchemist “炼金术士”"/>
@@ -354,9 +354,9 @@
     <text key="Code:Talos" text="Code:Talos “塔罗斯”清扫人形"/>
     <text key="Code:Centaurus" text="Code:Centaurus “肯陶罗斯”侦察人形"/>
     <text key="Code:Dactyl" text="Code:Dactyl “指灵”自走布雷机"/>
-    <text key="Code:Orthros" text="Code:Orthros “欧特鲁斯”近战系统"/> 
+    <text key="Code:Orthros" text="Code:Orthros “欧特鲁斯”近战系统"/>
     <text key="Code:Minotauros" text="Code:Minotauros “弥诺陶洛斯”巨型机甲"/>
-    <text key="Code:Pathfinder" text="Code:Pathfinder “尖兵”侦察单元" /> 
+    <text key="Code:Pathfinder" text="Code:Pathfinder “尖兵”侦察单元" />
     <text key="Typhon" text="提丰-Typhon 电磁坦克歼击车"/>
     <text key="Coeus" text="奎乌-Coeus 悬浮突击炮"/>
     <text key="Crius" text="克利俄斯-Crius 火力打击平台"/>
@@ -407,7 +407,7 @@
     <text key="Tareus-Miss Eve-[Charged Cannon]" text="塔亚柔斯-伊芙小姐-[蓄能炮]"/>
     <text key="Tareus-Miss Eve-[Anti Material Snipe]" text="塔亚柔斯-伊芙小姐-[反器材狙击枪]"/>
 
-    
+
     <!-- 帕拉蒂斯普通单位命名多以历史兵种为主 -->
     <!-- 帕拉蒂斯使用物品多以宗教相关 -->
 
@@ -419,7 +419,7 @@
     <text key="Silicification E.L.I.D." text="E.L.I.D. 重度硅化感染者"/>
 
     <!-- SF 支援台词 -->
-    
+
     <text key="Reinforcements - Paratrooper assault" text="增援部队 - 伞降突击单位"/>
     <text key="Requesting assault paratroopers" text="请求伞降突击单位支援"/>
     <text key="Reinforcements - Paratrooper scout" text="增援部队 - 伞降侦察单位"/>
@@ -433,7 +433,7 @@
     <text key="Request Jupiter Air-Strike" text="请求木星打击" />
     <text key="Confirm, Adjusting Jupiter rotation" text="确认,木星自旋调整中"/>
     <text key="Jupiter is Launching" text="木星火力投射中" />
-    
+
     <text key="Jaguar Strike Coverage" text="劫豹集群齐射"/>
     <text key="Request Jaguar Strike Coverage" text="请求劫豹集群齐射"/>
     <text key="Confirm, Giving orders to nodes" text="确认,各节点传递指令中"/>
@@ -447,7 +447,8 @@
     <text key="dinergate" text="兵蚁"/>
     <text key="dinergate!" text="兵蚁已送达"/>
 
-    <text key="It's time" text="是时候了"/>
+    <text key="It's time" text="时机已至"/>
+    <text key="Confirm, unlock" text="确认，解锁投送中" />
     <text key="SANGVIS FERRI,Attack!" text="铁血工造，进攻!"/>
 
     <text key="Assault Infanry" text="突击部队"/>
@@ -495,7 +496,7 @@
     <text key="Requesting assault paratroopers" text="认证通过，紧急节点指令，已部署应急突击部队"/>
     <text key="Requesting scout paratroopers" text="认证通过，紧急节点指令，已部署应急斥候部队"/>
 
-    
+
     <text key="Enemy contact, request infanry support" text="遭遇战，坐标已同步，请求步兵小队支援"/>
     <text key="Engage enemy, request Zircon infanry" text="侦测到敌方火力，呼叫锆石，请求装甲自律部队"/>
     <text key="Engage enemy, request Zircon mecha" text="坐标已上传，呼叫锆石，请求出动重型装甲部队"/>
@@ -507,7 +508,7 @@
     <text key="Engage enemy, request Typhon Droping" text="呼叫HQ，需求反装甲平台，请求投送提丰"/>
 
     <!-- 帕拉蒂斯 支援台词 -->
-    
+
     <text key="EOD Infanry" text="镇暴单位"/>
     <text key="Deploy Uhlan" text="部署枪骑兵"/>
     <text key="Deploy Cherub" text="部署圣歌风琴"/>
@@ -553,12 +554,12 @@
     <text key="KCCO Scanning bullet" text="特战部智能扫描分析弹"/>
     <text key="KCCO smart grenade 1" text="特战部智能追踪手雷"/>
     <text key="KCCO smart grenade 2" text="特战部智能追踪手雷"/>
-    <text key="KCCO smart grenade 3" text="特战部智能追踪手雷"/>    
+    <text key="KCCO smart grenade 3" text="特战部智能追踪手雷"/>
     <text key="Tracer Dart (Accurate)" text="定位信标(精确打击)"/>
     <text key="Tracer Dart (Ranged)" text="定位信标(范围覆盖)"/>
     <text key="Bounding mine" text="跳雷"/>
     <text key="Compass Deploy" text="指南针-Pyxis 轻型碉堡部署系统"/>
-    <text key="Emp Mine" text="EMP地雷"/>    
+    <text key="Emp Mine" text="EMP地雷"/>
     <text key="Ofanim's Might" text="座天使之威能"/>
     <text key="Seraph's Blaze" text="炽天使之怒火"/>
     <text key="Cherubim's Punish" text="智天使之惩戒"/>
@@ -649,7 +650,7 @@
     <text key="G36C(MOD3)-[You Who Takes the Step]-[Protector's Accord]" text="G36C(MOD3)-[迈出步伐的你]-[庇护者共识]" />
     <text key="G36C-[Red Beret]" text="G36C-[红色贝雷帽]" />
     <text key="G36C(MOD3)-[Red Beret]" text="G36C(MOD3)-[红色贝雷帽]" />
-    <text key="G36C(MOD3)-[Red Beret]-[Protector's Accord]" text="G36C(MOD3)-[红色贝雷帽]-[庇护者共识]" />    
+    <text key="G36C(MOD3)-[Red Beret]-[Protector's Accord]" text="G36C(MOD3)-[红色贝雷帽]-[庇护者共识]" />
     <text key="NEGEV" text="内格夫" />
     <text key="NEGEV-[Manic Blood]" text="内格夫-[狂躁血脉]" />
     <text key="G11(MOD3)-[Stance of the Assaulter]" text="G11(MOD3)-[突击者姿态]" />
@@ -691,17 +692,17 @@
     <text key="AS Val Shaft-[Fireworks of Dreams]" text="AS Val“巨浪”突击步枪-[梦花火]"/>
     <text key="AS Val Shaft-[Fireworks of Dreams]-[Damage Focus N]" text="AS Val“巨浪”突击步枪-[梦花火]-[火力专注N]"/>
     <text key="AS Val Shaft-[Fireworks of Dreams](MOD3)" text="AS Val“巨浪”突击步枪(MOD3)-[梦花火]"/>
-    <text key="AS Val Shaft-[Fireworks of Dreams](MOD3)-[Belief]" text="AS Val“巨浪”突击步枪(MOD3)-[梦花火]-[信念]"/>    
+    <text key="AS Val Shaft-[Fireworks of Dreams](MOD3)-[Belief]" text="AS Val“巨浪”突击步枪(MOD3)-[梦花火]-[信念]"/>
     <text key="AS Val Shaft-[Flower of LAN XI]" text="AS Val“巨浪”突击步枪-[兰溪花语]"/>
     <text key="AS Val Shaft-[Flower of LAN XI]-[Damage Focus N]" text="AS Val“巨浪”突击步枪-[兰溪花语]-[火力专注N]"/>
     <text key="AS Val Shaft-[Flower of LAN XI](MOD3)" text="AS Val“巨浪”突击步枪(MOD3)-[兰溪花语]"/>
-    <text key="AS Val Shaft-[Flower of LAN XI](MOD3)-[Belief]" text="AS Val“巨浪”突击步枪(MOD3)-[兰溪花语]-[信念]"/>    
+    <text key="AS Val Shaft-[Flower of LAN XI](MOD3)-[Belief]" text="AS Val“巨浪”突击步枪(MOD3)-[兰溪花语]-[信念]"/>
 
     <text key="G41-[Damage Focus T]" text="G41-[火力专注T]"/>
     <text key="F2000-[Damage Focus]" text="F2000-[火力专注]"/>
     <text key="OTS-14 Groza" text="OTS-14“闪电”突击步枪" />
     <text key="OTS-14 Groza-[Damage Focus N]" text="OTS-14“闪电”突击步枪-[火力专注N]" />
-    
+
     <text key="QBZ95" text="95式自动步枪" />
     <text key="QBZ97" text="97式自动步枪" />
     <text key="QBZ97-[Prayers in the Wind]" text="97式自动步枪-[风中祝祷]" />
@@ -728,7 +729,7 @@
     <text key="TAR-21" text="IMI Tar-21 塔沃尔21突击步枪"/>
     <text key="TAR-21-[Charge Focus]" text="IMI Tar-21 塔沃尔21突击步枪-[冲锋专注]"/>
     <text key="SPAS-12" text="弗兰基SPAS-12战斗霰弹枪"/>
-    <text key="SPAS-12-[Damage Focus SG]" text="弗兰基SPAS-12战斗霰弹枪-[火力专注SG]"/> 
+    <text key="SPAS-12-[Damage Focus SG]" text="弗兰基SPAS-12战斗霰弹枪-[火力专注SG]"/>
     <text key="SPAS-15" text="弗兰基SPAS-15战斗霰弹枪"/>
     <text key="SPAS-15-[Sonic Resonance]" text="弗兰基SPAS-15战斗霰弹枪-[音籁共鸣]"/>
     <text key="Nagant M1895 revolver" text="纳甘左轮M1895"/>
@@ -737,7 +738,7 @@
     <text key="PKP Pecheneg" text="PKP“佩切涅格”通用机枪"/>
     <text key="PKP Pecheneg-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[暴动宣告]"/>
     <text key="PKP Pecheneg-[PT2 Adjustable Stock]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]"/>
-    <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[暴动宣告]"/>    
+    <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[暴动宣告]"/>
     <text key="Dragunov SVD" text="德拉贡诺夫SVD狙击步枪"/>
     <text key="Dragunov SVD-[Assault Focus]" text="德拉贡诺夫SVD狙击步枪-[突击专注]"/>
     <text key="Dragunov SVD-EX" text="德拉贡诺夫SVD狙击步枪EX"/>
@@ -756,15 +757,15 @@
     <text key="Type 100(MOD3)-[Type Concentrate]" text="一〇〇式冲锋枪(MOD3)-[专注模式]"/>
     <text key="Type 100(MOD3)-[Type LIN+]" text="一〇〇式冲锋枪(MOD3)-[LIN动模式]"/>
 
-    
+
     <text key="IWS 2000-[Hawk Assault]" text="IWS 2000-[巨鹰攻势]"/>
     <text key="Mossberg Model 500" text="莫斯伯格M500霰弹枪"/>
     <text key="Mossberg Model 590" text="莫斯伯格M590霰弹枪"/>
     <text key="Mossberg Model 500(MOD3)" text="莫斯伯格M500霰弹枪(MOD3)"/>
     <text key="K11 weapon system" text="大宇K11武器系统"/>
     <text key="K11 weapon system-[Terror Grenades]" text="大宇K11武器系统-[恐惧榴弹]"/>
-    <text key="Bushmaster ACR" text="大毒蛇ACR突击步枪"/> 
-    <text key="Bushmaster ACR-[Shadow Strangling Tune]" text="大毒蛇ACR突击步枪-[暗影绞杀曲]"/> 
+    <text key="Bushmaster ACR" text="大毒蛇ACR突击步枪"/>
+    <text key="Bushmaster ACR-[Shadow Strangling Tune]" text="大毒蛇ACR突击步枪-[暗影绞杀曲]"/>
     <text key="General Liu" text="刘氏步枪"/>
     <text key="General Liu-[Shared Hatred]" text="刘氏步枪-[同仇敌忾]"/>
     <text key="Sturmgewehr 44" text="StG44突击步枪"/>
@@ -776,12 +777,12 @@
     <text key="SR3-MP Vikhr-[SR3 Special Suppressor]" text="SR3-MP“旋风”突击步枪-[SR3特制消音]"/>
     <text key="SR3-MP Vikhr-[SR3 Special Suppressor]-[Damage Focus]" text="SR3-MP“旋风”突击步枪-[SR3特制消音]-[火力专注]"/>
     <text key="SR3-MP Vikhr-[Shrine Maidens Super Lucky Draw]-[SR3 Special Suppressor]" text="SR3-MP“旋风”突击步枪-[神子上上签]-[SR3特制消音]"/>
-    <text key="SR3-MP Vikhr-[Shrine Maidens Super Lucky Draw]-[SR3 Special Suppressor]-[Damage Focus]" text="SR3-MP“旋风”突击步枪-[神子上上签]-[SR3特制消音]-[火力专注]"/>    
+    <text key="SR3-MP Vikhr-[Shrine Maidens Super Lucky Draw]-[SR3 Special Suppressor]-[Damage Focus]" text="SR3-MP“旋风”突击步枪-[神子上上签]-[SR3特制消音]-[火力专注]"/>
     <text key="Beretta LTLX 7000" text="伯莱塔LTLX7000霰弹枪"/>
     <text key="Beretta LTLX 7000-[Opposites Repel]" text="伯莱塔LTLX7000霰弹枪-[异类相斥]"/>
     <text key="AK-74U-[Repulsive Response]" text="AK-74U-[排斥反应]"/>
     <text key="Winchester Liberator" text="温彻斯特“解放者”霰弹枪"/>
-    <text key="Colt Defender" text="柯尔特“防卫者”霰弹枪"/> 
+    <text key="Colt Defender" text="柯尔特“防卫者”霰弹枪"/>
     <text key="Colt Defender-[Fang Blossom]" text="柯尔特“防卫者”霰弹枪-[獠牙绽放]"/>
     <text key="Walther P38" text="瓦尔特P38手枪"/>
     <text key="Beretta M9" text="伯莱塔M9手枪"/>
@@ -790,10 +791,10 @@
     <text key="Browning M1919A4" text="勃朗宁M1919A4机枪"/>
     <text key="Browning M1919A4-[Hunting Impulse]" text="勃朗宁M1919A4机枪-[猎杀冲动]"/>
     <text key="Browning M1919A4(MOD3)" text="勃朗宁M1919A4机枪(MOD3)"/>
-    <text key="Browning M1919A4(MOD3)-[Macro Shock]" text="勃朗宁M1919A4机枪(MOD3)-[巨噬震慑]"/>    
-    
+    <text key="Browning M1919A4(MOD3)-[Macro Shock]" text="勃朗宁M1919A4机枪(MOD3)-[巨噬震慑]"/>
+
     <text key="Super Shorty" text="“超级肖蒂”霰弹枪"/>
-    
+
     <text key="Walther PPK" text="瓦尔特PPK手枪"/>
     <text key="Walther PPK-[Mach Tempest]" text="瓦尔特PPK手枪-[烈旋音波]"/>
     <text key="Walther PPK-[Foliage Romance]" text="瓦尔特PPK手枪-[恋如树影]"/>
@@ -808,7 +809,7 @@
     <text key="M1 Garand" text="M1加兰德半自动步枪"/>
     <text key="M1 Garand-[Rifle Grenade]" text="M1加兰德半自动步枪-[60mm枪榴弹发射器]"/>
 
-    
+
     <text key="RPK-16-[Wits of the Silver Fox]" text="RPK-16-[银狐的狡黠]"/>
     <text key="AK-15(MOD3)-[Eye of the White Mastiff]" text="AK-15(MOD3)-[白獒之瞳]"/>
     <text key="Summer Killer" text="夏日杀手"/>
@@ -855,8 +856,8 @@
     <text key="IWI Jericho 941" text="IWI杰里科941" />
     <text key="IWI Tavor TS12" text="IWI塔沃尔TS12"/>
     <text key="PP-9 KLIN" text="PP-9 KLIN“楔子”微型冲锋枪"/>
-    <text key="Beretta Model 38" text="伯莱塔38型冲锋枪"/> 
-    <text key="Beretta Model 38(MOD3)" text="伯莱塔38型冲锋枪(MOD3)"/> 
+    <text key="Beretta Model 38" text="伯莱塔38型冲锋枪"/>
+    <text key="Beretta Model 38(MOD3)" text="伯莱塔38型冲锋枪(MOD3)"/>
     <text key="AR57-[Complex Modification]" text="AR57-[复合改装]"/>
     <text key="MG 42-[Damage Focus MG]" text="MG 42-[火力专注 MG]"/>
     <text key="9A-91-[Damage Focus N]" text="9A-91-[火力专注N]"/>
@@ -884,7 +885,7 @@
     <text key="Hawk Type 97(MOD3)" text="Hawk 97式霰弹枪(MOD3)"/>
     <text key="Jackhammer MK3A1" text="MK3A1“汽锤”霰弹枪"/>
     <text key="Jackhammer MK3A1-[The art of maintenance]" text="MK3A1“汽锤”霰弹枪-[MK3A1的维修艺术]"/>
-    
+
     <text key="Daewoo K5" text="大宇K5半自动手枪"/>
     <text key="Daewoo K5(MOD3)" text="大宇K5半自动手枪(MOD3)"/>
     <text key="Type 80 GPMG" text="80式通用机枪" />
@@ -899,8 +900,8 @@
     <text key="Karabiner 98k - Scoped" text="毛瑟Kar98k步枪 - 狙击型" />
     <text key="Karabiner 98k - Assault" text="毛瑟Kar98k步枪 - 突击型" />
     <text key="Karabiner 98k(MOD3) - Scoped" text="毛瑟Kar98k步枪(MOD3) - 狙击型" />
-    <text key="Karabiner 98k(MOD3) - Assault" text="毛瑟Kar98k步枪(MOD3) - 突击型" />    
-    
+    <text key="Karabiner 98k(MOD3) - Assault" text="毛瑟Kar98k步枪(MOD3) - 突击型" />
+
     <text key="Steyr TMP" text="施泰尔TMP冲锋枪"/>
     <text key="Kolibri" text="Kolibri“蜂鸟”2mm手枪"/>
 
@@ -922,7 +923,7 @@
 
     <text key="C14 Timberwolf MRSWS" text="C14“大灰狼”中距狙击武器系统"/>
     <text key="C14 Timberwolf MRSWS-[Lunar Arclight]" text="C14“大灰狼”中距狙击武器系统-[白月弧光]"/>
-    
+
     <text key="M240L-[Heart of the Paladin]" text="M240L-[帕拉丁之心]"/>
 
     <text key="QBU-88-[Rushing Cloud]" text="QBU-88-[乱石崩云]"/>
@@ -973,7 +974,7 @@
     <text key="Type 79 SMG" text="79式冲锋枪"/>
     <text key="Type 79 SMG(MOD3)" text="79式冲锋枪(MOD3)"/>
 
-    
+
     <text key="Gewehr 43" text="格韦尔Gewehr 43半自动步枪"/>
     <text key="Gewehr 43-[7.92 KURZ]" text="格韦尔Gewehr 43半自动步枪-[7.92 KURZ]"/>
     <text key="M3 Grease Gun" text="M3“黄油枪”"/>
@@ -986,7 +987,7 @@
     <text key="MG3-[Full Moon's Gaze]-[Lock and Load]" text="MG3通用机枪-[满月请睁眼]-[蓄势待发]"/>
     <text key="MG3(MOD3)-[Full Moon's Gaze]" text="MG3通用机枪(MOD3)-[满月请睁眼]"/>
     <text key="MG3(MOD3)-[Full Moon's Gaze]-[Supercompressed Bulletswarm]" text="MG3通用机枪(MOD3)-[满月请睁眼]-[超压弹群]"/>
-    
+
     <text key="ZB vz.26" text="ZB-26式轻机枪"/>
     <text key="ZB vz.26-[The 1000th Paper Crane]" text="ZB-26式轻机枪-[第1000只纸鹤]"/>
     <text key="ZB vz.26-[Cat of the Night]" text="ZB-26式轻机枪-[夜衔蝉]"/>
@@ -1000,7 +1001,7 @@
     <text key="Micro Uzi(MOD3)" text="微型乌兹(MOD3)"/>
     <text key="Desert Eagle" text="沙漠之鹰" />
     <text key="Desert Eagle-[Deterrent Mark]" text="沙漠之鹰-[威慑印记]" />
-    
+
     <text key="OTs-12 Tiss" text="OTs-12“紫杉树”突击步枪" />
     <text key="S.W. Model 327 Revolver" text="史密斯威森Model 327左轮手枪" />
     <text key="McMillan TAC-50" text="麦克米兰TAC-50狙击步枪"/>
@@ -1065,8 +1066,8 @@
 
     <text key="Lebedev PL-15K(AK-12)" text="列别捷夫PL-15K手枪(AK-12配备)"/>
     <text key="The Fix by Q Sniper Rifle" text="TF-Q狙击步枪"/>
-    <text key="MP-446 Viking" text="MP-446“维京人”手枪" />    
-    <text key="MP-446 Viking(MOD3)" text="MP-446“维京人”手枪(MOD3)" />    
+    <text key="MP-446 Viking" text="MP-446“维京人”手枪" />
+    <text key="MP-446 Viking(MOD3)" text="MP-446“维京人”手枪(MOD3)" />
     <text key="Mk 12 SPR" text="Mk 12特别用途步枪"/>
     <text key="Calico M950A" text="卡利柯M950A手枪"/>
     <text key="Calico M950A(MOD3)" text="卡利柯M950A手枪(MOD3)"/>
@@ -1091,7 +1092,7 @@
     <text key="GK-Vespid SWAP" text="Vespid SWAP 强化型胡蜂"/>
     <text key="GK-Dragoon" text="Dragoon 龙骑兵"/>
     <text key="GK-Jaguar" text="Jaguar “劫豹”轻型作战机甲"/>
-    
+
     <text key="GK-Agent" text="Agent “代理人”"/>
     <text key="GK-Alchemist" text="Alchemist “炼金术士”"/>
     <text key="GK-Architect" text="Architect “建筑师”"/>
@@ -1156,8 +1157,8 @@
     <text key="Mk 47 Striker-[40x53mm MK285 PPHE/SD]" text="Mk 47 Striker自动榴弹发射器-[40x53mm MK285 可编程空爆榴弹]"/>
     <text key="CMMG Mk47 Mutant(Mk 47)" text="CMMG Mk47 Mutant(Mk 47配备)"/>
 
-    
-    
+
+
     <!-- 皮肤翻译 -->
     <text key="CETME Ameli MG82-[Gift-selling Christmas Tree]" text="赛特迈 阿梅利MG82通用机枪-[卖礼物的圣诞树]" />
     <text key="CETME Ameli MG82-[Gift-selling Christmas Tree]-[Lock and Load N]" text="赛特迈 阿梅利MG82通用机枪-[卖礼物的圣诞树]-[蓄势待发N]" />
@@ -1194,8 +1195,8 @@
     <text key="AK-47-[Lord of War]-[Raid Focus]" text="AK-47-[战争之王]-[强袭专注]" />
     <text key="ST-AR15-[A hat Floating to the Sea of Flowers]" text="ST-AR15-[飘向花海的礼帽]" />
     <text key="ST-AR15-[Sleepy Summer Wind]" text="ST-AR15-[午夏憩风]" />
-    <text key="ST-AR15-[Breeze on a Spring Day]" text="ST-AR15-[春日幻风]" />    
-    <text key="ST-AR15-[Dreamscape Prisoner]" text="ST-AR15-[梦境的囚困者]" />    
+    <text key="ST-AR15-[Breeze on a Spring Day]" text="ST-AR15-[春日幻风]" />
+    <text key="ST-AR15-[Dreamscape Prisoner]" text="ST-AR15-[梦境的囚困者]" />
     <text key="ART556-[Louts White]" text="ART556-[莲花白]" />
     <text key="ART556-[Louts White]-[Charge Focus]" text="ART556-[莲花白]-[冲锋专注]" />
     <text key="ART556-[Chimney Sweaping Girl]" text="ART556-[扫烟囱的小姑娘]" />
@@ -1242,7 +1243,7 @@
     <text key="MP-446 Viking-[Obstinate Noise]" text="MP-446“维京人”手枪-[顽劣杂音]" />
     <text key="MP-446 Viking-[Sunflower]" text="MP-446“维京人”手枪-[向日葵]" />
     <text key="MP-446 Viking(MOD3)-[Obstinate Noise]" text="MP-446“维京人”手枪(MOD3)-[顽劣杂音]" />
-    <text key="MP-446 Viking(MOD3)-[Sunflower]" text="MP-446“维京人”手枪(MOD3)-[向日葵]" />    
+    <text key="MP-446 Viking(MOD3)-[Sunflower]" text="MP-446“维京人”手枪(MOD3)-[向日葵]" />
     <text key="NEGEV-[Little Fugitive]" text="内格夫-[小流浪家]" />
     <text key="NEGEV-[Obsidian Princess]" text="内格夫-[黑石姬]" />
     <text key="NEGEV-[Little Fugitive]-[Manic Blood]" text="内格夫-[小流浪家]-[狂躁血脉]" />
@@ -1289,7 +1290,7 @@
     <text key="Nagant M1895 revolver(MOD3)-[Blushing Snow Princess]-[Seven Tone Paean]" text="纳甘左轮M1895(MOD3)-[胭雪公主]-[七音之凯歌]"/>
     <text key="Nagant M1895 revolver-[Cream in the Nebula]" text="纳甘左轮M1895-[星云忌廉]" />
     <text key="Nagant M1895 revolver(MOD3)-[Cream in the Nebula]" text="纳甘左轮M1895(MOD3)-[星云忌廉]" />
-    <text key="Nagant M1895 revolver(MOD3)-[Cream in the Nebula]-[Seven Tone Paean]" text="纳甘左轮M1895(MOD3)-[星云忌廉]-[七音之凯歌]"/>    
+    <text key="Nagant M1895 revolver(MOD3)-[Cream in the Nebula]-[Seven Tone Paean]" text="纳甘左轮M1895(MOD3)-[星云忌廉]-[七音之凯歌]"/>
     <text key="HOWA Type 89-[Reindeer Manifesto]" text="丰和89式自突击步枪-[麋鹿宣言]" />
     <text key="HK21-[Silver Fox's 1/9 Platform]" text="HK21通用机枪-[银狐的1/9月台]" />
     <text key="FABARM FP-6-[Satellite of Love]" text="FABARM FP-6-[恋爱卫星]" />
@@ -1345,15 +1346,15 @@
     <text key="FightLite SCR-[Song of Frozen Wind]" text="FightLite SCR-[阮吟霜枫]"/>
     <text key="Fedorov Avtomat M1916-[Breath of Colored Mint]" text="菲德洛夫M1916自动步枪-[薄荷色的吐息]"/>
     <text key="AEK-999 Barsuk-[Peerless Yakuza Rider]" text="AEK-999“獾”通用机枪-[极道车神]"/>
-    <text key="AEK-999 Barsuk-[Peerless Yakuza Rider]-[Hunting Impulse N]" text="AEK-999“獾”通用机枪-[极道车神]-[猎杀冲动N]"/>    
+    <text key="AEK-999 Barsuk-[Peerless Yakuza Rider]-[Hunting Impulse N]" text="AEK-999“獾”通用机枪-[极道车神]-[猎杀冲动N]"/>
 
-    <text key="USAS-12-[VRAIN Power]-[Frenzied Assault]" text="USAS-12-[VRAIN Power]-[狂热突袭]"/>        
+    <text key="USAS-12-[VRAIN Power]-[Frenzied Assault]" text="USAS-12-[VRAIN Power]-[狂热突袭]"/>
     <text key="USAS-12-[Polymer Rounds Drum]" text="USAS-12-[聚合物弹鼓]"/>
-    <text key="USAS-12-[Polymer Rounds Drum]-[Frenzied Assault]" text="USAS-12-[聚合物弹鼓]-[狂热突袭]"/>        
+    <text key="USAS-12-[Polymer Rounds Drum]-[Frenzied Assault]" text="USAS-12-[聚合物弹鼓]-[狂热突袭]"/>
     <text key="USAS-12-[VRAIN Power]-[Polymer Rounds Drum]" text="USAS-12-[VRAIN Power]-[聚合物弹鼓]"/>
-    <text key="USAS-12-[VRAIN Power]-[Polymer Rounds Drum]-[Frenzied Assault]" text="USAS-12-[VRAIN Power]-[聚合物弹鼓]-[狂热突袭]"/>        
+    <text key="USAS-12-[VRAIN Power]-[Polymer Rounds Drum]-[Frenzied Assault]" text="USAS-12-[VRAIN Power]-[聚合物弹鼓]-[狂热突袭]"/>
 
-    
+
     <text key="AK-12-['Lucia']" text="AK-12-['露契娅']"/>
     <text key="AK-12-['Lucia']-[Eye of the Snow Wolf]" text="AK-12-['露契娅']-[雪狼之眼]"/>
     <text key="AK-12-[Sorbet Era]" text="AK-12-[冰沙时代]"/>
@@ -1400,34 +1401,34 @@
     <text key="Type 100-[Treasure Buried Deep Within]" text="一〇〇式冲锋枪-[埋入心底的宝藏]"/>
     <text key="Type 100-[Treasure Buried Deep Within]-[Cherry Blossom's Reflection]" text="一〇〇式冲锋枪-[埋入心底的宝藏]-[樱反像]"/>
     <text key="Type 100(MOD3)-[Treasure Buried Deep Within]-[Type Concentrate]" text="一〇〇式冲锋枪(MOD3)-[埋入心底的宝藏]-[专注模式]"/>
-    <text key="Type 100(MOD3)-[Treasure Buried Deep Within]-[Type LIN+]" text="一〇〇式冲锋枪(MOD3)-[埋入心底的宝藏]-[LIN动模式]"/>    
+    <text key="Type 100(MOD3)-[Treasure Buried Deep Within]-[Type LIN+]" text="一〇〇式冲锋枪(MOD3)-[埋入心底的宝藏]-[LIN动模式]"/>
     <text key="Mossberg Model 590-[Snowy Nil]" text="莫斯伯格M590霰弹枪-[雪朝颜]"/>
     <text key="Beretta LTLX 7000-[Dancing Shrine Maiden]" text="伯莱塔LTLX7000霰弹枪-[巫姬翩舞起]"/>
     <text key="Beretta LTLX 7000-[Dancing Shrine Maiden]-[Opposites Repel]" text="伯莱塔LTLX7000霰弹枪-[巫姬翩舞起]-[异类相斥]"/>
     <text key="Beretta LTLX 7000-[Night-Tide Invitation]" text="伯莱塔LTLX7000霰弹枪-[夜潮的邀约]"/>
-    <text key="Beretta LTLX 7000-[Night-Tide Invitation]-[Opposites Repel]" text="伯莱塔LTLX7000霰弹枪-[夜潮的邀约]-[异类相斥]"/>    
+    <text key="Beretta LTLX 7000-[Night-Tide Invitation]-[Opposites Repel]" text="伯莱塔LTLX7000霰弹枪-[夜潮的邀约]-[异类相斥]"/>
     <text key="Beretta LTLX 7000-[Macallan Intoxication]" text="伯莱塔LTLX7000霰弹枪-[醉情麦卡伦]"/>
-    <text key="Beretta LTLX 7000-[Macallan Intoxication]-[Opposites Repel]" text="伯莱塔LTLX7000霰弹枪-[醉情麦卡伦]-[异类相斥]"/>    
-    
+    <text key="Beretta LTLX 7000-[Macallan Intoxication]-[Opposites Repel]" text="伯莱塔LTLX7000霰弹枪-[醉情麦卡伦]-[异类相斥]"/>
+
     <text key="DSR-50-[Pantone Peony]" text="DSR-50-[红牡丹]"/>
     <text key="DSR-50-[Highest Bidder]" text="DSR-50-[最高出价]"/>
-    <text key="Colt Defender-[Lily's Reverie]" text="柯尔特“防卫者”霰弹枪-[梦倒仙]"/> 
-    <text key="Colt Defender-[Lily's Reverie]-[Fang Blossom]" text="柯尔特“防卫者”霰弹枪-[梦倒仙]-[獠牙绽放]"/> 
+    <text key="Colt Defender-[Lily's Reverie]" text="柯尔特“防卫者”霰弹枪-[梦倒仙]"/>
+    <text key="Colt Defender-[Lily's Reverie]-[Fang Blossom]" text="柯尔特“防卫者”霰弹枪-[梦倒仙]-[獠牙绽放]"/>
     <text key="Walther P38-[High Sorceress Apprentice]" text="瓦尔特P38手枪-[魔女高徒]"/>
     <text key="AK-74M-[Sashimi Chef with Harpoon]" text="AK-74M-[戟与鱼脍师]"/>
     <text key="M1 Garand-[Beach Princess]" text="M1加兰德半自动步枪-[沙滩公主]"/>
     <text key="M1 Garand-[Beach Princess]-[Rifle Grenade]" text="M1加兰德半自动步枪-[沙滩公主]-[60mm枪榴弹发射器]"/>
     <text key="M1 Garand-[Letter from the Winter Cypress]" text="M1加兰德半自动步枪-[冬柏来信]"/>
-    <text key="M1 Garand-[Letter from the Winter Cypress]-[Rifle Grenade]" text="M1加兰德半自动步枪-[冬柏来信]-[60mm枪榴弹发射器]"/>    
+    <text key="M1 Garand-[Letter from the Winter Cypress]-[Rifle Grenade]" text="M1加兰德半自动步枪-[冬柏来信]-[60mm枪榴弹发射器]"/>
     <text key="M1 Garand-[Deer Calls in Winter]" text="M1加兰德半自动步枪-[冬季鹿鸣]"/>
-    <text key="M1 Garand-[Deer Calls in Winter]-[Rifle Grenade]" text="M1加兰德半自动步枪-[冬季鹿鸣]-[60mm枪榴弹发射器]"/>    
+    <text key="M1 Garand-[Deer Calls in Winter]-[Rifle Grenade]" text="M1加兰德半自动步枪-[冬季鹿鸣]-[60mm枪榴弹发射器]"/>
     <text key="MG4-[Survival Club Member]" text="MG4-[生存社员]"/>
     <text key="MG4-[Sneaker Costume]" text="MG4-[运动服]"/>
     <text key="AK-15-['Alvin']" text="AK-15-['艾尔文']"/>
     <text key="IWS 2000-[Sand Castle Terminator]" text="IWS 2000-[沙堡终结者]"/>
     <text key="IWS 2000-[Sand Castle Terminator]-[Hawk Assault]" text="IWS 2000-[沙堡终结者]-[巨鹰攻势]"/>
     <text key="IWS 2000-[Edelweiss]" text="IWS 2000-[薄雪绒]"/>
-    <text key="IWS 2000-[Edelweiss]-[Hawk Assault]" text="IWS 2000-[薄雪绒]-[巨鹰攻势]"/>    
+    <text key="IWS 2000-[Edelweiss]-[Hawk Assault]" text="IWS 2000-[薄雪绒]-[巨鹰攻势]"/>
     <text key="SV-98-[Waitress]" text="SV-98-[女服务生]"/>
     <text key="SV-98-[Piercing the Heart]" text="SV-98-[正中红心！]"/>
     <text key="SV-98 (MOD3)-[Waitress]" text="SV-98 (MOD3)-[女服务生]"/>
@@ -1447,7 +1448,7 @@
     <text key="Kord-[Dead Silent Dancer]" text="Kord-[死寂舞者]"/>
     <text key="Kord-[Dead Silent Dancer]-[High Pressure Assault]" text="Kord-[死寂舞者]-[高压冲击]"/>
     <text key="Kord-[Captain Kord]" text="Kord-[寇德船长]"/>
-    <text key="Kord-[Captain Kord]-[High Pressure Assault]" text="Kord-[寇德船长]-[高压冲击]"/>    
+    <text key="Kord-[Captain Kord]-[High Pressure Assault]" text="Kord-[寇德船长]-[高压冲击]"/>
     <text key="MG36-[Crimson Mallow]" text="MG36-[悬铃绯]"/>
     <text key="MG36-[Bamboo Shadow Samurai]" text="MG36-[竹影清兵卫]"/>
     <text key="MG36-[Knight of Kudzu]" text="MG36-[葛根姜骑士]"/>
@@ -1460,20 +1461,20 @@
     <text key="PKP Pecheneg-[Bamboo's Pride]" text="PKP“佩切涅格”通用机枪-[青竹矜]"/>
     <text key="PKP Pecheneg-[Bamboo's Pride]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[青竹矜]-[暴动宣告]"/>
     <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[Bamboo's Pride]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[青竹矜]"/>
-    <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[Bamboo's Pride]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[青竹矜]-[暴动宣告]"/>    
+    <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[Bamboo's Pride]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[青竹矜]-[暴动宣告]"/>
     <text key="PKP Pecheneg-[After-Rain Assault Squad]" text="PKP“佩切涅格”通用机枪-[雨后冲锋队]"/>
     <text key="PKP Pecheneg-[After-Rain Assault Squad]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[雨后冲锋队]-[暴动宣告]"/>
     <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[After-Rain Assault Squad]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[雨后冲锋队]"/>
-    <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[After-Rain Assault Squad]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[雨后冲锋队]-[暴动宣告]"/>    
+    <text key="PKP Pecheneg-[PT2 Adjustable Stock]-[After-Rain Assault Squad]-[Ultimatum]" text="PKP“佩切涅格”通用机枪-[PT2可调节后托]-[雨后冲锋队]-[暴动宣告]"/>
 
     <text key="MG 42-[Witch in Apprenticeship]" text="MG 42-[女巫见习中]"/>
     <text key="MG 42-[Witch in Apprenticeship]-[Damage Focus MG]" text="MG 42-[女巫见习中]-[火力专注 MG]"/>
     <text key="MG 42-[Shining Chess Star]" text="MG 42-[耀闪棋星]"/>
-    <text key="MG 42-[Shining Chess Star]-[Damage Focus MG]" text="MG 42-[耀闪棋星]-[火力专注 MG]"/>    
+    <text key="MG 42-[Shining Chess Star]-[Damage Focus MG]" text="MG 42-[耀闪棋星]-[火力专注 MG]"/>
     <text key="General Liu-[Fox's Shadow of Drooping Branches]" text="刘氏步枪-[垂枝梦狐影]"/>
     <text key="General Liu-[Fox's Shadow of Drooping Branches]-[Shared Hatred]" text="刘氏步枪-[垂枝梦狐影]-[同仇敌忾]"/>
     <text key="General Liu-[Musings in the Morn]" text="刘氏步枪-[悠思之晨]"/>
-    <text key="General Liu-[Musings in the Morn]-[Shared Hatred]" text="刘氏步枪-[悠思之晨]-[同仇敌忾]"/>    
+    <text key="General Liu-[Musings in the Morn]-[Shared Hatred]" text="刘氏步枪-[悠思之晨]-[同仇敌忾]"/>
     <text key="MAB PA-15-[Highschool Heartbeat Story]" text="MAB PA-15-[高校心跳物语]"/>
     <text key="MAB PA-15-[Phantom Thief of Champagne]" text="MAB PA-15-[香槟怪盗]"/>
     <text key="MAB PA-15-[Marvellous Herb Cake]" text="MAB PA-15-[奇妙山药饼]"/>
@@ -1495,27 +1496,27 @@
     <text key="M1903 Springfield-[O Holy Night]-[AP]" text="M1903春田步枪-[圣善夜的祝福]-[国家竞赛穿甲弹]"/>
     <text key="M1903 Springfield-[Stirring Mermaid]" text="M1903春田步枪-[睡醒的人鱼]"/>
     <text key="M1903 Springfield-[Stirring Mermaid]-[Experiment]" text="M1903春田步枪-[睡醒的人鱼]-[佩德森实验装置]"/>
-    <text key="M1903 Springfield-[Stirring Mermaid]-[AP]" text="M1903春田步枪-[睡醒的人鱼]-[国家竞赛穿甲弹]"/>    
+    <text key="M1903 Springfield-[Stirring Mermaid]-[AP]" text="M1903春田步枪-[睡醒的人鱼]-[国家竞赛穿甲弹]"/>
     <text key="VSK-94-[Christmas Eve Detective]" text="VSK-94-[圣夜警探]"/>
     <text key="Walther WA2000-[Date in the Snow]" text="瓦尔特WA2000狙击步枪-[雪下赴约者]"/>
     <text key="Walther WA2000-[SB 2.5-10x56]-[Date in the Snow]" text="瓦尔特WA2000狙击步枪-[SB 2.5-10x56]-[雪下赴约者]"/>
     <text key="Walther WA2000-[SB 2.5-10x56]-[Date in the Snow]-[Assault Focus]" text="瓦尔特WA2000狙击步枪-[SB 2.5-10x56]-[雪下赴约者]-[突击专注]"/>
     <text key="Walther WA2000-[Op. Manta Ray]" text="瓦尔特WA2000狙击步枪-[魔鬼鱼行动]"/>
     <text key="Walther WA2000-[SB 2.5-10x56]-[Op. Manta Ray]" text="瓦尔特WA2000狙击步枪-[SB 2.5-10x56]-[魔鬼鱼行动]"/>
-    <text key="Walther WA2000-[SB 2.5-10x56]-[Op. Manta Ray]-[Assault Focus]" text="瓦尔特WA2000狙击步枪-[SB 2.5-10x56]-[魔鬼鱼行动]-[突击专注]"/>    
+    <text key="Walther WA2000-[SB 2.5-10x56]-[Op. Manta Ray]-[Assault Focus]" text="瓦尔特WA2000狙击步枪-[SB 2.5-10x56]-[魔鬼鱼行动]-[突击专注]"/>
     <text key="KP-31 Suomi-[Korvantunturi Pixie]" text="KP-31 索米冲锋枪-[耳朵山的雪妖精]"/>
     <text key="KP-31 Suomi(MOD3)-[Korvantunturi Pixie]" text="KP-31 索米冲锋枪(MOD3)-[耳朵山的雪妖精]"/>
     <text key="KP-31 Suomi-[Mission for Happiness]" text="KP-31 索米冲锋枪-[幸福使命]"/>
-    <text key="KP-31 Suomi(MOD3)-[Mission for Happiness]" text="KP-31 索米冲锋枪(MOD3)-[幸福使命]"/>    
+    <text key="KP-31 Suomi(MOD3)-[Mission for Happiness]" text="KP-31 索米冲锋枪(MOD3)-[幸福使命]"/>
     <text key="KP-31 Suomi-[Midsummer Pixie]" text="KP-31 索米冲锋枪-[仲夏夜的精灵]"/>
-    <text key="KP-31 Suomi(MOD3)-[Midsummer Pixie]" text="KP-31 索米冲锋枪(MOD3)-[仲夏夜的精灵]"/>    
+    <text key="KP-31 Suomi(MOD3)-[Midsummer Pixie]" text="KP-31 索米冲锋枪(MOD3)-[仲夏夜的精灵]"/>
 
-    <text key="Beretta Model 38-[Ossola's Daisy]" text="伯莱塔38型冲锋枪-[奥索拉山麓的雏菊]"/> 
-    <text key="Beretta Model 38(MOD3)-[Ossola's Daisy]" text="伯莱塔38型冲锋枪(MOD3)-[奥索拉山麓的雏菊]"/> 
+    <text key="Beretta Model 38-[Ossola's Daisy]" text="伯莱塔38型冲锋枪-[奥索拉山麓的雏菊]"/>
+    <text key="Beretta Model 38(MOD3)-[Ossola's Daisy]" text="伯莱塔38型冲锋枪(MOD3)-[奥索拉山麓的雏菊]"/>
     <text key="Colt M1873-[Wish Upon A Star]" text="柯尔特左轮 SAA M1873-[直达星星的愿望]"/>
     <text key="Colt M1873(MOD3)-[Wish Upon A Star]" text="柯尔特左轮 SAA M1873(MOD3)-[直达星星的愿望]"/>
     <text key="Colt M1873-[Queen of Miracles]" text="柯尔特左轮 SAA M1873-[奇迹女王]"/>
-    <text key="Colt M1873(MOD3)-[Queen of Miracles]" text="柯尔特左轮 SAA M1873(MOD3)-[奇迹女王]"/>    
+    <text key="Colt M1873(MOD3)-[Queen of Miracles]" text="柯尔特左轮 SAA M1873(MOD3)-[奇迹女王]"/>
     <text key="Tokarev 33-[Griffon Dancer]" text="托卡列夫TT-33 手枪-[格里芬的舞娘]" />
     <text key="Tokarev 33-[A Couple's Journey]" text="托卡列夫TT-33 手枪-[两人的旅程]" />
     <text key="Tokarev 33-[Wet Crow Shadow]" text="托卡列夫TT-33 手枪-[濡鸦魅影]" />
@@ -1530,7 +1531,7 @@
     <text key="M1911-[Breaker of the Sky]" text="M1911-[天空的击破者]" />
     <text key="M1911(MOD3)-[Breaker of the Sky]" text="M1911(MOD3)-[天空的击破者]" />
     <text key="M1911-[Tin Soldier's Big Day]" text="M1911-[锡兵奇妙日]" />
-    <text key="M1911(MOD3)-[Tin Soldier's Big Day]" text="M1911(MOD3)-[锡兵奇妙日]" />    
+    <text key="M1911(MOD3)-[Tin Soldier's Big Day]" text="M1911(MOD3)-[锡兵奇妙日]" />
     <text key="HS Produkt VHS-[Swan Lake Scherzo]" text="VHS突击步枪-[谐谑天鹅湖]"/>
     <text key="HS Produkt VHS-[Keeper on Page 8]" text="VHS突击步枪-[第八页守密人]"/>
 
@@ -1551,13 +1552,13 @@
     <text key="Beretta Px4 Storm(MOD3)-[Queen of Christmas Morning]" text="伯莱塔Px4 风暴(MOD3)-[圣诞晨间女王]"/>
     <text key="Beretta Cx4 Storm-[Marvellous Poolside Christmas Encounter]" text="伯莱塔Cx4 风暴-[泳池边的圣诞奇遇]"/>
     <text key="Brenten-[Fluffy Berry Tart]" text="布伦·坦半自动手枪-[绒绒草莓挞]"/>
-    <text key="Lusa-[Winter Deer latté]" text="卢萨冲锋枪-[冬鹿拿铁]"/>    
-    <text key="Lusa-[Coastal Vanguard]" text="卢萨冲锋枪-[滨海前锋]"/>    
-    <text key="PM1910-[Queen's Tower Party]" text="PM1910-[女王的高塔派对]"/>    
-    <text key="APC556-[Ballad of MuLan]" text="APC556-[木兰谣]"/>    
-    <text key="A-545-[Bloom of the Drunken Tea]" text="A-545-[醉茗咲]"/>    
-    <text key="A-545-[Bloom of the Drunken Tea]-[Booze Formation]" text="A-545-[醉茗咲]-[豪饮战阵]"/>    
-    <text key="QBZ-191-[Lone Pine Walker]" text="QBZ-191-[孤松行]"/>    
+    <text key="Lusa-[Winter Deer latté]" text="卢萨冲锋枪-[冬鹿拿铁]"/>
+    <text key="Lusa-[Coastal Vanguard]" text="卢萨冲锋枪-[滨海前锋]"/>
+    <text key="PM1910-[Queen's Tower Party]" text="PM1910-[女王的高塔派对]"/>
+    <text key="APC556-[Ballad of MuLan]" text="APC556-[木兰谣]"/>
+    <text key="A-545-[Bloom of the Drunken Tea]" text="A-545-[醉茗咲]"/>
+    <text key="A-545-[Bloom of the Drunken Tea]-[Booze Formation]" text="A-545-[醉茗咲]-[豪饮战阵]"/>
+    <text key="QBZ-191-[Lone Pine Walker]" text="QBZ-191-[孤松行]"/>
     <text key="QBZ-191-[Fragrance in Ink]" text="QBZ-191-[冷香染墨]"/>
     <text key="QBU-88-[Dance of the Trumpet Vine]" text="QBU-88-[舞凌霄]"/>
     <text key="QBU-88-[Dance of the Trumpet Vine]-[Rushing Cloud]" text="QBU-88-[舞凌霄]-[乱石崩云]"/>
@@ -1573,7 +1574,7 @@
     <text key="Type 56(MOD3)-[Pink Pear Blossom]-[Glorious Disengagement]" text="56式半自动步枪(MOD3)-[扶绛梨]-[荣耀解脱]"/>
     <text key="Hawk Type 97-[Drunken Petals Underfoot]" text="Hawk 97式霰弹枪-[花下踟躇醉]" />
     <text key="Hawk Type 97(MOD3)-[Drunken Petals Underfoot]" text="Hawk 97式霰弹枪(MOD3)-[花下踟躇醉]"/>
-    
+
     <text key="UMP9-[Shiba Inu Scout]" text="UMP9-[柴犬侦查员]"/>
     <text key="UMP9(MOD3)-[Shiba Inu Scout]" text="UMP9(MOD3)-[柴犬侦查员]"/>
     <text key="UMP9-[Wayfarer of the Profound]" text="UMP9-[幽玄旅人]"/>
@@ -1587,7 +1588,7 @@
     <text key="DP12-[Echeveria Lantern]" text="DP12-[花月夜行灯]" />
     <text key="DP12(MOD3)-[Echeveria Lantern]" text="DP12(MOD3)-[花月夜行灯]" />
     <text key="DP12-[Morning Fable]" text="DP12-[熙光寓言]" />
-    <text key="DP12(MOD3)-[Morning Fable]" text="DP12(MOD3)-[熙光寓言]" />    
+    <text key="DP12(MOD3)-[Morning Fable]" text="DP12(MOD3)-[熙光寓言]" />
     <text key="DP12-[Misty Cross]" text="DP12-[雾叙十字星]" />
     <text key="DP12(MOD3)-[Misty Cross]" text="DP12(MOD3)-[雾叙十字星]" />
     <text key="XM8-[The Rose Chess Player's Confession]" text="XM8-[玫瑰棋手的告白]"/>
@@ -1595,15 +1596,15 @@
     <text key="Karabiner 98k-[Roses in Hand] - Scoped" text="毛瑟Kar98k步枪-[手心的朱砂痣] - 狙击型" />
     <text key="Karabiner 98k-[Roses in Hand] - Assault" text="毛瑟Kar98k步枪-[手心的朱砂痣] - 突击型" />
     <text key="Karabiner 98k(MOD3)-[Roses in Hand] - Scoped" text="毛瑟Kar98k步枪(MOD3)-[手心的朱砂痣] - 狙击型" />
-    <text key="Karabiner 98k(MOD3)-[Roses in Hand] - Assault" text="毛瑟Kar98k步枪(MOD3)-[手心的朱砂痣] - 突击型" />    
+    <text key="Karabiner 98k(MOD3)-[Roses in Hand] - Assault" text="毛瑟Kar98k步枪(MOD3)-[手心的朱砂痣] - 突击型" />
     <text key="Karabiner 98k-[Corner Fox-trot] - Scoped" text="毛瑟Kar98k步枪-[转角狐步舞] - 狙击型" />
     <text key="Karabiner 98k-[Corner Fox-trot] - Assault" text="毛瑟Kar98k步枪-[转角狐步舞] - 突击型" />
     <text key="Karabiner 98k(MOD3)-[Corner Fox-trot] - Scoped" text="毛瑟Kar98k步枪(MOD3)-[转角狐步舞] - 狙击型" />
-    <text key="Karabiner 98k(MOD3)-[Corner Fox-trot] - Assault" text="毛瑟Kar98k步枪(MOD3)-[转角狐步舞] - 突击型" />    
+    <text key="Karabiner 98k(MOD3)-[Corner Fox-trot] - Assault" text="毛瑟Kar98k步枪(MOD3)-[转角狐步舞] - 突击型" />
     <text key="Karabiner 98k-[Inari at Hatsu-uma Festival] - Scoped" text="毛瑟Kar98k步枪-[初午稻荷福] - 狙击型" />
     <text key="Karabiner 98k-[Inari at Hatsu-uma Festival] - Assault" text="毛瑟Kar98k步枪-[初午稻荷福] - 突击型" />
     <text key="Karabiner 98k(MOD3)-[Inari at Hatsu-uma Festival] - Scoped" text="毛瑟Kar98k步枪(MOD3)-[初午稻荷福] - 狙击型" />
-    <text key="Karabiner 98k(MOD3)-[Inari at Hatsu-uma Festival] - Assault" text="毛瑟Kar98k步枪(MOD3)-[初午稻荷福] - 突击型" />            
+    <text key="Karabiner 98k(MOD3)-[Inari at Hatsu-uma Festival] - Assault" text="毛瑟Kar98k步枪(MOD3)-[初午稻荷福] - 突击型" />
     <text key="Lee-Enfield No4.Mk I-[Lifelong Protector] - Scoped" text="李-恩菲尔德No4.Mk I步枪-[毕生守护] - 狙击型"/>
     <text key="Lee-Enfield No4.Mk I-[Lifelong Protector] - Assault" text="李-恩菲尔德No4.Mk I步枪-[毕生守护] - 突击型"/>
     <text key="Lee-Enfield(MOD3) L42A1-[Lifelong Protector] - Scoped" text="李-恩菲尔德L42A1步枪(MOD3)-[毕生守护] - 狙击型"/>
@@ -1612,7 +1613,7 @@
     <text key="RMB-93(MOD3)-[Untouchable Moonlit Lover]" text="RMB-93(MOD3)-[触不到的月光情人]"/>
     <text key="RMB-93-[Berry Tipsy Night]" text="RMB-93-[莓果微醺之夜]"/>
     <text key="RMB-93(MOD3)-[Berry Tipsy Night]" text="RMB-93(MOD3)-[莓果微醺之夜]"/>
-    
+
     <text key="Micro Uzi-[New Maple Silhouette]" text="微型乌兹-[新橙剪影]"/>
     <text key="Micro Uzi(MOD3)-[New Maple Silhouette]" text="微型乌兹(MOD3)-[新橙剪影]"/>
 
@@ -1636,8 +1637,8 @@
     <text key="Daewoo K2-[Together under the flowers]" text="大宇K2突击步枪-[相守在花下]"/>
 
 
-    
-    
+
+
 
 
     <text key="HK416(MOD3)-[Primrose-Flavored Foil Candy]" text="HK416(MOD3)-[千宵草味的锡纸糖]" />
@@ -1663,13 +1664,13 @@
     <text key="M4A1(MOD3)-[Girl`s Balloon Roaming]" text="M4A1(MOD3)-[少女的气球漫游记]" />
     <text key="M4A1(MOD3)-[Girl`s Balloon Roaming]-[Mark of the avenger]" text="M4A1(MOD3)-[少女的气球漫游记]-[伸冤者印记]" />
     <text key="M4A1(MOD3)-[Sunshine through the Pines]" text="M4A1(MOD3)-[松间曦光]" />
-    <text key="M4A1(MOD3)-[Sunshine through the Pines]-[Mark of the avenger]" text="M4A1(MOD3)-[松间曦光]-[伸冤者印记]" />    
+    <text key="M4A1(MOD3)-[Sunshine through the Pines]-[Mark of the avenger]" text="M4A1(MOD3)-[松间曦光]-[伸冤者印记]" />
     <text key="ST-AR15(MOD3)-[A hat Floating to the Sea of Flowers]-[SPR]" text="ST-AR15(MOD3)-[飘向花海的礼帽]" />
     <text key="ST-AR15(MOD3)-[A hat Floating to the Sea of Flowers]-[Crime and punishment]" text="ST-AR15(MOD3)-[飘向花海的礼帽]-[罪与罚]" />
     <text key="ST-AR15(MOD3)-[Sleepy Summer Wind]-[SPR]" text="ST-AR15(MOD3)-[午夏憩风]" />
-    <text key="ST-AR15(MOD3)-[Sleepy Summer Wind]-[Crime and punishment]" text="ST-AR15(MOD3)-[午夏憩风]-[罪与罚]" />    
+    <text key="ST-AR15(MOD3)-[Sleepy Summer Wind]-[Crime and punishment]" text="ST-AR15(MOD3)-[午夏憩风]-[罪与罚]" />
     <text key="ST-AR15(MOD3)-[Breeze on a Spring Day]-[SPR]" text="ST-AR15(MOD3)-[春日幻风]" />
-    <text key="ST-AR15(MOD3)-[Breeze on a Spring Day]-[Crime and punishment]" text="ST-AR15(MOD3)-[春日幻风]-[罪与罚]" />    
+    <text key="ST-AR15(MOD3)-[Breeze on a Spring Day]-[Crime and punishment]" text="ST-AR15(MOD3)-[春日幻风]-[罪与罚]" />
     <text key="ST-AR15(MOD3)-[Dreamscape Prisoner]-[SPR]" text="ST-AR15(MOD3)-[梦境的囚困者]" />
     <text key="ST-AR15(MOD3)-[Dreamscape Prisoner]-[Crime and punishment]" text="ST-AR15(MOD3)-[梦境的囚困者]-[罪与罚]" />
     <text key="IDW(MOD3)-[Cat in a box]" text="IDW(MOD3)-[箱中之猫]" />
@@ -1748,7 +1749,7 @@
     <text key="MG4(MOD3)-[Survival Club Member]" text="MG4(MOD3)-[生存社员]"/>
     <text key="MG4(MOD3)-[Survival Club Member]-[Haunted House Hammer]" text="MG4(MOD3)-[生存社员]-[鬼屋之锤]"/>
     <text key="MG4(MOD3)-[Sneaker Costume]" text="MG4(MOD3)-[运动服]"/>
-    <text key="MG4(MOD3)-[Sneaker Costume]-[Haunted House Hammer]" text="MG4(MOD3)-[运动服]-[鬼屋之锤]"/>    
+    <text key="MG4(MOD3)-[Sneaker Costume]-[Haunted House Hammer]" text="MG4(MOD3)-[运动服]-[鬼屋之锤]"/>
     <text key="AK-15(MOD3)-['Alvin']" text="AK-15(MOD3)-['艾尔文']"/>
     <text key="AK-15(MOD3)-['Alvin']-[Eye of the White Mastiff]" text="AK-15(MOD3)-['艾尔文']-[白獒之瞳]"/>
     <text key="Hanyang-made Type88(MOD3)-[White Comet]" text="汉阳造88式步枪(MOD3)-[纯白流星负愿而行]"/>
@@ -1782,7 +1783,7 @@
     <text key="Saiwa juggernaut" text="Juggernaut-辛搭乘机模型"/><!-- . -->
 
     <!-- 斯人已逝 2023.2.25 By 冥府乌鸦 -->
-    
+
     <!-- 文本Key翻译 -->
     <!-- 以下为原版翻译汇编 -->
     <text key="default" text="默认" />
@@ -2056,13 +2057,13 @@
     <text key="Repair required" text="需要修理" />
 
     <text key="Bandage" text="绷带" />
- 
+
     <text key="move to backpack" text="移至背包" />
     <text key="equip" text="装备" />
     <text key="move to armory" text="移至军械库" />
     <text key="move to stash" text="移至储藏处" />
     <text key="drop on ground" text="扔在地上" />
-    <text key="single/multi item mode" text="单一/多种物品模式" />    
+    <text key="single/multi item mode" text="单一/多种物品模式" />
 
     <text key="Splinter Point" text="分歧点"/>
     <text key="Stroke Dead-Center" text="冲程止点" />
@@ -2076,8 +2077,8 @@
     <text key="* destroy &#37;target_count Crius" text="* 摧毁 &#37;target_count 辆 克利俄斯-Crius 火力支援平台" />
     <text key="* destroy %target_count Recce Centre" text="* 摧毁 &#37;target_count 座 侦察中枢" />
 
-    
-    
+
+
     <text key="Operation Cube" text="魔方行动" />
     <text key="Seven-Step Puzzle" text="七步谜题" />
     <text key="Corner Breaker" text="角先破解" />
@@ -2125,8 +2126,8 @@
 
     <text key="I.O.P. Doll Logger [Equip for manual]" text="I.O.P. 人形录入证 [装备以查看教程]"/>
     <text key="Doll logged success" text="&#37;doll_key 录入成功 现在您的图鉴里有&#37;doll_num位战术人形" />
-    <text key="Doll logged failed" text="&#37;doll_key 录入失败,请尝试切换模式并重试,如仍无法解决请截图并报告给管理员"/>     
-    <text key="Doll logged already" text="&#37;doll_key 录入失败,您已经在图鉴中烙印了这位人形"/>     
+    <text key="Doll logged failed" text="&#37;doll_key 录入失败,请尝试切换模式并重试,如仍无法解决请截图并报告给管理员"/>
+    <text key="Doll logged already" text="&#37;doll_key 录入失败,您已经在图鉴中烙印了这位人形"/>
     <text key="Help - logger system" text="装备人形录入证后，于军械库卖出你想录入的人形，如果有副模式请切换为主模式再进行录入操作，随后该人形将永久与存档绑定。"/>>
     <text key="Help - logger system title" text="[图鉴录入机制]"/>
     <text key="Help - command" text="/craft 从图鉴恢复指定编号人形 &#37;PS
@@ -2137,12 +2138,12 @@
 /re 重新部署(120s冷却)"/>
     <text key="Help - command title" text="[所有指令]"/>
 
-    <text key="Doll query failed" text="您输入的编号有误，请重试"/>     
-    <text key="Doll query format error" text="您输入的参数有误，需要输入/craft 皮肤编号 模式"/>     
+    <text key="Doll query failed" text="您输入的编号有误，请重试"/>
+    <text key="Doll query format error" text="您输入的参数有误，需要输入/craft 皮肤编号 模式"/>
 
-    <text key="Logger Query Result" text= "皮肤编号:&#37;skin_index 名字:&#37;name 种类:&#37;mode"/> 
-    <text key="Logger Query nothing" text="在您的图鉴中未能查询到相关人形"/> 
-    <text key="Logger Timeout" text="操作超时，请重新输入相关指令"/> 
+    <text key="Logger Query Result" text= "皮肤编号:&#37;skin_index 名字:&#37;name 种类:&#37;mode"/>
+    <text key="Logger Query nothing" text="在您的图鉴中未能查询到相关人形"/>
+    <text key="Logger Timeout" text="操作超时，请重新输入相关指令"/>
     <text key="Logger Mask Auto" text="您的图鉴中没有该人形，已自动帮您录入图鉴"/>
     <text key="Logger info query" text="已收集战术人形：&#37;doll_number/&#37;all_dollnum位&#37;PS
 您的战术人形收集率为&#37;doll_collect%"/>
@@ -2156,8 +2157,8 @@
 击败首领: &#37;waifu_boss
 战役胜利: &#37;waifu_matchwin
 载具摧毁: &#37;waifu_vehicle"/>
-    <text key="Waifu info failed" text="啊嘞,您好像和这位人形不是很熟的样子,再去多陪陪她吧!"/> 
-    
+    <text key="Waifu info failed" text="啊嘞,您好像和这位人形不是很熟的样子,再去多陪陪她吧!"/>
+
     <text key="craft progression start" text="已确认可恢复的人形列表，请输入/craft 皮肤编号 模式 来恢复人形" />
     <text key="craft success" text="已从图鉴中将人形&#37;doll_name恢复成功" />
     <text key="craft not found" text="没有编号为&#37;index 皮肤编号为&#37;skin_index 模式为&#37;mode的人形" />
@@ -2177,7 +2178,7 @@
 
     <text key="vehicle limited" text="[无可用载具] 战场中的载具维护压力超出了我们的后勤能力，请等待载具可用。" />
 
-    
+
 
     <text key="call event,not enough point" text="[战术妖精] 战术点不够呼叫本次支援哦~ 还缺少&#37;num点战术点" />
     <text key="call event,cost point" text="[战术妖精] 呼叫成功~ 消耗了&#37;cost_num点战术点,您还有&#37;num点可供调遣捏~" />

--- a/packages/GFL_Castling/scripts/core/gfl_skill_info.as
+++ b/packages/GFL_Castling/scripts/core/gfl_skill_info.as
@@ -193,6 +193,7 @@ dictionary gameSkillIndex = {
 
         {"evo3_skill",62},
 
+        //强无敌空投，暂时弃用
         {"manticore_summon",63},
 
         {"spawn_gager_knight",64},

--- a/packages/GFL_Castling/scripts/trackers/GFLskill.as
+++ b/packages/GFL_Castling/scripts/trackers/GFLskill.as
@@ -1762,7 +1762,7 @@ class GFLskill : Tracker {
 				break;
 			}
 
-            case 63:{ //强无敌空投
+            case 63:{ //强无敌空投，暂时弃用
 				int characterId = event.getIntAttribute("character_id");
 				const XmlElement@ character = getCharacterInfo(m_metagame, characterId);
 				if (character is null) return;

--- a/packages/GFL_Castling/scripts/trackers/basic_command_handler.as
+++ b/packages/GFL_Castling/scripts/trackers/basic_command_handler.as
@@ -25,7 +25,7 @@ dictionary songIndex = {
 };
 
 array<array<float>> songInfo = {
-	
+
 	// 对应上面的歌曲名设置一下音量和时长(单位：秒)就行
 
 	// 列表开头，不用管
@@ -48,7 +48,7 @@ class BasicCommandHandler : Tracker {
 	BasicCommandHandler(Metagame@ metagame) {
 		@m_metagame = @metagame;
 	}
-	
+
 	// ----------------------------------------------------
 	protected void handleChatEvent(const XmlElement@ event) {
 		// player_id
@@ -57,7 +57,7 @@ class BasicCommandHandler : Tracker {
 		// global
 
 		string message = event.getStringAttribute("message");
-		// for the most part, chat events aren't commands, so check that first 
+		// for the most part, chat events aren't commands, so check that first
 		if (!startsWith(message, "/")) {
 			return;
 		}
@@ -67,7 +67,7 @@ class BasicCommandHandler : Tracker {
 		if (checkCommand(message, "chat")) {
 			if (message=="/chat1") {
 				const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
-				if (playerInfo is null) return;				
+				if (playerInfo is null) return;
 				string strname= playerInfo.getStringAttribute("name");
 				dictionary a;
 				a["%name"] = strname;
@@ -115,7 +115,7 @@ class BasicCommandHandler : Tracker {
 				playSound(m_metagame, "objective_priority.wav", 0); //high priority
 				sendFactionMessageKey(m_metagame, 0,"quickchat5d",a,2.0);
 				sendFactionMessageKeySaidAsCharacter(m_metagame, 0, cId,"quickchat5",dictionary(),0.9);
-			}		
+			}
 			if (message=="/chat6") {
 				const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 				if (playerInfo is null) return;
@@ -377,93 +377,93 @@ class BasicCommandHandler : Tracker {
 		else if (checkCommand(message, "dance2")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dancing, raise hands",true,true);
 		}
 		else if (checkCommand(message, "dance3")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dancing, beat hands",true,true);
 		}
 		else if (checkCommand(message, "dance4")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dancing, ten years old ass",true,true);
 		}
 		else if (checkCommand(message, "dance5")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dancing, helltaker",true,true);
 		}
 		else if (checkCommand(message, "dance6")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dancing, phut hon",true,true);
 		}
 		else if (checkCommand(message, "dance7")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dancing, zoufang",true,true);
 		}
 		else if (checkCommand(message, "dance8")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dance, groove battle",true,true);
-		}		
+		}
 		else if (checkCommand(message, "dance9")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"dance, moonwalk",true,true);
-		}												
+		}
 		else if (checkCommand(message, "action1")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"celebrating",true,true);
 		}
 		else if (checkCommand(message, "action2")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"celebrating2",true,true);
 		}
 		else if (checkCommand(message, "action3")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"sunbath_crossleg",true,true);
 		}
 		else if (checkCommand(message, "action4")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"lay on ground and shake",true,true);
 		}
 		else if (checkCommand(message, "action5")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"infinite_rotation",true,true);
 		}
 		else if (checkCommand(message, "action6")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"handstand",true,true);
 		}
 		else if (checkCommand(message, "action7")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"salute",true,true);
-		}        
+		}
 		else if (checkCommand(message, "help")) {
 			notify(m_metagame, "Help - command", dictionary(), "misc", senderId, true, "Help - command title", 1.0);
 		}
@@ -500,7 +500,7 @@ class BasicCommandHandler : Tracker {
 
 		// 	if(singLastTime>0){
 		// 		dictionary a;
-        //         a["%time"] = ""+singLastTime;  
+        //         a["%time"] = ""+singLastTime;
 		// 		sendPrivateMessageKey(m_metagame,playerId,"VODcooldown",a);
 		// 		return;
 		// 	}
@@ -518,12 +518,12 @@ class BasicCommandHandler : Tracker {
 		// 			_log("Add up time: " + float(songInfo[songId][1]));
 		// 			singLastTime += float(songInfo[songId][1]);
 		// 			playSoundAtLocation(m_metagame,jud_sing_file,fId,c_pos,float(songInfo[songId][0]));
-		// 		}				
+		// 		}
 		// 		else{
 		// 			sendPrivateMessageKey(m_metagame,playerId,"VODerror");
 		// 		}
 		// 	}
-		// }			
+		// }
 		else if (checkCommand(message, "sidinfo")) {
 			handleSidInfo(message,senderId);
 		} else if (checkCommand(message, "kick_id")) {
@@ -554,12 +554,12 @@ class BasicCommandHandler : Tracker {
 				}
 			}
 		}
-		
+
 		// admin only from here on
 		if (!m_metagame.getAdminManager().isAdmin(sender, senderId)) {
 			return;
 		}
-        
+
 		else if (message=="/shout") {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
@@ -569,12 +569,12 @@ class BasicCommandHandler : Tracker {
 			int cId= playerInfo.getIntAttribute("character_id");
 			sendFactionMessageKey(m_metagame, 0,"quickchat5d",a,2.0);
 			sendFactionMessageKeySaidAsCharacter(m_metagame, 0, cId,"quickchat5",dictionary(),0.9);
-		}	        
+		}
 
 		else if (checkCommand(message, "anime1")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			if (playerInfo is null) return;
-			int characterId= playerInfo.getIntAttribute("character_id");			
+			int characterId= playerInfo.getIntAttribute("character_id");
 			playAnimationKey(m_metagame,characterId,"celebrating2",true,true);
 		}
 
@@ -647,7 +647,7 @@ class BasicCommandHandler : Tracker {
 		} else  if(checkCommand(message, "kill_aa")) {
 			for (uint f = 1; f < 3; ++f) {
 				array<const XmlElement@>@ vehicles = getVehicles(m_metagame, f, "aa_emplacement.vehicle");
-				
+
 				for (uint i = 0; i < vehicles.size(); ++i) {
 					const XmlElement@ vehicle = vehicles[i];
 					int id = vehicle.getIntAttribute("id");
@@ -680,11 +680,11 @@ class BasicCommandHandler : Tracker {
 			}
 		} else  if(checkCommand(message, "god")) {
 			// .. god vest!
-			spawnInstanceNearPlayer(senderId, "god_vest.carry_item", "carry_item");    		
+			spawnInstanceNearPlayer(senderId, "god_vest.carry_item", "carry_item");
         } else if (checkCommand(message, "create_vehicle")) {
 			spawnInstanceNearPlayer(senderId, "special_cargo_vehicle1.vehicle", "vehicle");
 		} else if (checkCommand(message, "jeep")) {
-			spawnInstanceNearPlayer(senderId, "jeep.vehicle", "vehicle");      
+			spawnInstanceNearPlayer(senderId, "jeep.vehicle", "vehicle");
 		} else  if(checkCommand(message, "c4")) {
 			spawnInstanceNearPlayer(senderId, "c4.projectile", "projectile");
 		} else  if(checkCommand(message, "rewardtest")) {
@@ -692,8 +692,8 @@ class BasicCommandHandler : Tracker {
 			spawnInstanceNearPlayer(senderId, "city_gifts.drop_reward", "grenade");
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			const XmlElement@ characterInfo = getCharacterInfo(m_metagame, playerInfo.getIntAttribute("character_id"));
-			Vector3 pos = stringToVector3(characterInfo.getStringAttribute("position"));					
-			string c = 
+			Vector3 pos = stringToVector3(characterInfo.getStringAttribute("position"));
+			string c =
 				"<command class='create_instance'" +
 				" faction_id='" + 0 + "'" +
 				" instance_class='grenade'" +
@@ -705,40 +705,40 @@ class BasicCommandHandler : Tracker {
 			const XmlElement@ characterInfo = getCharacterInfo(m_metagame, playerInfo.getIntAttribute("character_id"));
 			Vector3 pos = stringToVector3(characterInfo.getStringAttribute("position"));
 			pos = pos.add(Vector3(0,1.5,0));
-			string c = 
+			string c =
 				"<command class='create_instance'" +
 				" faction_id='" + 0 + "'" +
 				" instance_class='grenade'" +
 				" instance_key='" + "selfstun.projectile" + "'" +
 				" position='" + pos.toString() + "'" +
-				" character_id='" + playerInfo.getIntAttribute("character_id") + "'/>";				
-			m_metagame.getComms().send(c);		
+				" character_id='" + playerInfo.getIntAttribute("character_id") + "'/>";
+			m_metagame.getComms().send(c);
 		} else  if(checkCommand(message, "noneme")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			const XmlElement@ characterInfo = getCharacterInfo(m_metagame, playerInfo.getIntAttribute("character_id"));
-			Vector3 pos = stringToVector3(characterInfo.getStringAttribute("position"));	
-			pos = pos.add(Vector3(0,1.5,0));				
-			string c = 
+			Vector3 pos = stringToVector3(characterInfo.getStringAttribute("position"));
+			pos = pos.add(Vector3(0,1.5,0));
+			string c =
 				"<command class='create_instance'" +
 				" faction_id='" + 0 + "'" +
 				" instance_class='grenade'" +
 				" instance_key='" + "selfnone.projectile" + "'" +
 				" position='" + pos.toString() + "'" +
-				" character_id='" + playerInfo.getIntAttribute("character_id") + "'/>";				
-			m_metagame.getComms().send(c);				
+				" character_id='" + playerInfo.getIntAttribute("character_id") + "'/>";
+			m_metagame.getComms().send(c);
 		} else  if(checkCommand(message, "particle")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			const XmlElement@ characterInfo = getCharacterInfo(m_metagame, playerInfo.getIntAttribute("character_id"));
-			Vector3 pos = stringToVector3(playerInfo.getStringAttribute("aim_target"));	
+			Vector3 pos = stringToVector3(playerInfo.getStringAttribute("aim_target"));
 			pos=pos.add(Vector3(0,1,0));
-			string c = 
+			string c =
 				"<command class='create_instance'" +
 				" faction_id='" + 0 + "'" +
 				" instance_class='grenade'" +
 				" instance_key='" + "test_particle.projectile" + "'" +
 				" position='" + pos.toString() + "'" +
-				" character_id='" + playerInfo.getIntAttribute("character_id") + "'/>";				
-			m_metagame.getComms().send(c);								      
+				" character_id='" + playerInfo.getIntAttribute("character_id") + "'/>";
+			m_metagame.getComms().send(c);
         } else if (checkCommand(message, "squad")) {
 			spawnInstanceNearPlayer(senderId, "default", "soldier", 0);
             spawnInstanceNearPlayer(senderId, "default", "soldier", 0);
@@ -749,7 +749,7 @@ class BasicCommandHandler : Tracker {
             spawnInstanceNearPlayer(senderId, "default", "soldier", 0);
             spawnInstanceNearPlayer(senderId, "default", "soldier", 0);
             spawnInstanceNearPlayer(senderId, "default", "soldier", 0);
-            spawnInstanceNearPlayer(senderId, "default", "soldier", 0);            
+            spawnInstanceNearPlayer(senderId, "default", "soldier", 0);
         } else if (checkCommand(message, "esquad")) {
 			spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
             spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
@@ -760,9 +760,9 @@ class BasicCommandHandler : Tracker {
             spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
             spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
             spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
-            spawnInstanceNearPlayer(senderId, "default", "soldier", 1);                 
+            spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
 		} else if (checkCommand(message, "spawnbhh")) {
-			spawnInstanceNearPlayer(senderId, "Paradeus_roarer", "soldier", 0);            
+			spawnInstanceNearPlayer(senderId, "Paradeus_roarer", "soldier", 0);
 		} else if (checkCommand(message, "foe")) {
 			spawnInstanceNearPlayer(senderId, "default", "soldier", 1);
 		} else if (checkCommand(message, "eod")) {
@@ -770,7 +770,7 @@ class BasicCommandHandler : Tracker {
 		} else if (checkCommand(message, "sniper")) {
 			spawnInstanceNearPlayer(senderId, "sniper", "soldier", 0);
 		} else if (checkCommand(message, "dog")) {
-			spawnInstanceNearPlayer(senderId, "dog", "soldier", 0);    	
+			spawnInstanceNearPlayer(senderId, "dog", "soldier", 0);
 		} else if (checkCommand(message, "gb1")) {
 			spawnInstanceNearPlayer(senderId, "complete_box.carry_item", "carry_item", 0);
 			spawnInstanceNearPlayer(senderId, "complete_box.carry_item", "carry_item", 0);
@@ -779,18 +779,18 @@ class BasicCommandHandler : Tracker {
 		} else if (checkCommand(message, "gb2")) {
 			spawnInstanceNearPlayer(senderId, "core_mask.carry_item", "carry_item", 0);
 		} else if (checkCommand(message, "gb3")) {
-			spawnInstanceNearPlayer(senderId, "firecontrol.carry_item", "carry_item", 0);        
-			spawnInstanceNearPlayer(senderId, "firecontrol.carry_item", "carry_item", 0);        
-			spawnInstanceNearPlayer(senderId, "firecontrol.carry_item", "carry_item", 0);       
+			spawnInstanceNearPlayer(senderId, "firecontrol.carry_item", "carry_item", 0);
+			spawnInstanceNearPlayer(senderId, "firecontrol.carry_item", "carry_item", 0);
+			spawnInstanceNearPlayer(senderId, "firecontrol.carry_item", "carry_item", 0);
 		} else if (checkCommand(message, "gb4")) {
-			spawnInstanceNearPlayer(senderId, "equip_only_ticket.carry_item", "carry_item", 0);        
-			spawnInstanceNearPlayer(senderId, "equip_only_ticket.carry_item", "carry_item", 0);        
-			spawnInstanceNearPlayer(senderId, "equip_only_ticket.carry_item", "carry_item", 0);   			 
+			spawnInstanceNearPlayer(senderId, "equip_only_ticket.carry_item", "carry_item", 0);
+			spawnInstanceNearPlayer(senderId, "equip_only_ticket.carry_item", "carry_item", 0);
+			spawnInstanceNearPlayer(senderId, "equip_only_ticket.carry_item", "carry_item", 0);
 		} else if (checkCommand(message, "gb5")) {
-			spawnInstanceNearPlayer(senderId, "black_card.carry_item", "carry_item", 0); 
+			spawnInstanceNearPlayer(senderId, "black_card.carry_item", "carry_item", 0);
             spawnInstanceNearPlayer(senderId, "black_card.carry_item", "carry_item", 0);
 		} else if (checkCommand(message, "gb6")) {
-			spawnInstanceNearPlayer(senderId, "upgrade_masterkey.carry_item", "carry_item", 0); 
+			spawnInstanceNearPlayer(senderId, "upgrade_masterkey.carry_item", "carry_item", 0);
             spawnInstanceNearPlayer(senderId, "upgrade_masterkey.carry_item", "carry_item", 0);
             spawnInstanceNearPlayer(senderId, "upgrade_masterkey.carry_item", "carry_item", 0);
 		} else if (checkCommand(message, "cb2")) {
@@ -798,26 +798,29 @@ class BasicCommandHandler : Tracker {
             spawnInstanceNearPlayer(senderId, "sf_box.carry_item", "carry_item", 0);
             spawnInstanceNearPlayer(senderId, "sf_box.carry_item", "carry_item", 0);
             spawnInstanceNearPlayer(senderId, "sf_box.carry_item", "carry_item", 0);
-            spawnInstanceNearPlayer(senderId, "sf_box.carry_item", "carry_item", 0);                        			
+            spawnInstanceNearPlayer(senderId, "sf_box.carry_item", "carry_item", 0);
 		} else  if(checkCommand(message, "kill_rt")) {
 			destroyAllEnemyVehicles("radar_tower.vehicle");
 		} else  if(checkCommand(message, "kill_own_rt")) {
 			destroyAllFactionVehicles(0, "radar_tower.vehicle");
 		} else  if(checkCommand(message, "kill_rj")) {
 			destroyAllEnemyVehicles("radio_jammer.vehicle");
+		} else if(checkCommand(message, "killself")) {
+			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
+			killCharacter(m_metagame, playerInfo.getIntAttribute("character_id"));
 		} else  if(checkCommand(message, "mustela")) {
-			spawnInstanceNearPlayer(senderId, "wiesel_tow.vehicle", "vehicle", 0);          
+			spawnInstanceNearPlayer(senderId, "wiesel_tow.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "javelin")) {
-			spawnInstanceNearPlayer(senderId, "gkw_consume_javelin.weapon", "weapon", 0);        
+			spawnInstanceNearPlayer(senderId, "gkw_consume_javelin.weapon", "weapon", 0);
 		} else  if(checkCommand(message, "lblm1")) {
-			spawnInstanceNearPlayer(senderId, "binoculars_aek999_spawn_fairy.weapon", "weapon", 0);        
-			spawnInstanceNearPlayer(senderId, "binoculars_wheelchair_spawn_fairy.weapon", "weapon", 0);        
+			spawnInstanceNearPlayer(senderId, "binoculars_aek999_spawn_fairy.weapon", "weapon", 0);
+			spawnInstanceNearPlayer(senderId, "binoculars_wheelchair_spawn_fairy.weapon", "weapon", 0);
 		} else  if(checkCommand(message, "humvee")) {
-			spawnInstanceNearPlayer(senderId, "sf_humvee.vehicle", "vehicle", 0);        
+			spawnInstanceNearPlayer(senderId, "sf_humvee.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "javelin")) {
-			spawnInstanceNearPlayer(senderId, "javelin_ap.weapon", "weapon", 0);        
+			spawnInstanceNearPlayer(senderId, "javelin_ap.weapon", "weapon", 0);
 		} else  if(checkCommand(message, "vectorflame")) {
-			spawnInstanceNearPlayer(senderId, "gkw_vector_549_skill.weapon", "weapon", 0);        
+			spawnInstanceNearPlayer(senderId, "gkw_vector_549_skill.weapon", "weapon", 0);
 		} else  if(checkCommand(message, "complete_campaign")) {
 			m_metagame.getComms().send("<command class='set_campaign_status' show_stats='1'/>");
 		} else if (checkCommand(message, "enable_gps")) {
@@ -825,22 +828,22 @@ class BasicCommandHandler : Tracker {
 		} else  if(checkCommand(message, "icecream")) {
 			// int randIndex=rand(1,4);
 			// switch (randIndex){
-			// 	case 1: spawnInstanceNearPlayer(senderId, "icecream.vehicle", "vehicle", 0);break;      
+			// 	case 1: spawnInstanceNearPlayer(senderId, "icecream.vehicle", "vehicle", 0);break;
 			// 	case 2: spawnInstanceNearPlayer(senderId, "icecream_Solar_Sea.vehicle", "vehicle", 0);break;
 			// 	case 3: spawnInstanceNearPlayer(senderId, "icecream_akino.vehicle", "vehicle", 0);break;
 			// 	case 4: spawnInstanceNearPlayer(senderId, "icecream_connexion.vehicle", "vehicle", 0);break;
 			// }
 			spawnInstanceNearPlayer(senderId, "icecream.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "rj")) {
-			spawnInstanceNearPlayer(senderId, "deployed_mortar.vehicle", "vehicle", 1);        
+			spawnInstanceNearPlayer(senderId, "deployed_mortar.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "cat")) {
 			spawnInstanceNearPlayer(senderId, "darkcat.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "mortar")) {
 			spawnInstanceNearPlayer(senderId, "mortar_truck.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawntower")) {
-			spawnInstanceNearPlayer(senderId, "radar_tower.vehicle", "vehicle", 0); 
+			spawnInstanceNearPlayer(senderId, "radar_tower.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "lblm")) {
-			spawnInstanceNearPlayer(senderId, "wheelchair_lblm.vehicle", "vehicle", 0); 
+			spawnInstanceNearPlayer(senderId, "wheelchair_lblm.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "dapc")) {
 			spawnInstanceNearPlayer(senderId, "default_apc_1.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "acar1")) {
@@ -850,23 +853,23 @@ class BasicCommandHandler : Tracker {
 		} else  if(checkCommand(message, "acar3")) {
 			spawnInstanceNearPlayer(senderId, "default_car_3.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnaa")) {
-			spawnInstanceNearPlayer(senderId, "aa_emplacement.vehicle", "vehicle", 1); 
+			spawnInstanceNearPlayer(senderId, "aa_emplacement.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "spawnjpt")) {
-			spawnInstanceNearPlayer(senderId, "sf_jupiter.vehicle", "vehicle", 0); 		
+			spawnInstanceNearPlayer(senderId, "sf_jupiter.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnejpt")) {
-			spawnInstanceNearPlayer(senderId, "sf_jupiter.vehicle", "vehicle", 1); 		
+			spawnInstanceNearPlayer(senderId, "sf_jupiter.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "spawnjwag")) {
-			spawnInstanceNearPlayer(senderId, "sf_JWAG.vehicle", "vehicle", 0); 
+			spawnInstanceNearPlayer(senderId, "sf_JWAG.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnmoth")) {
-			spawnInstanceNearPlayer(senderId, "par_moth.vehicle", "vehicle", 1); 		
+			spawnInstanceNearPlayer(senderId, "par_moth.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "moth1")) {
-			spawnInstanceNearPlayer(senderId, "par_moth_ruin.vehicle", "vehicle", 1); 		
+			spawnInstanceNearPlayer(senderId, "par_moth_ruin.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "spawnuhlan")) {
 			spawnInstanceNearPlayer(senderId, "par_uhlan.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnsand")) {
 			spawnInstanceNearPlayer(senderId, "sandstorm.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn boat")) {
-			spawnInstanceNearPlayer(senderId, "rubber_boat.vehicle", "vehicle", 0);			
+			spawnInstanceNearPlayer(senderId, "rubber_boat.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawncoeus")) {
 			spawnInstanceNearPlayer(senderId, "coeus.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn is2")) {
@@ -876,9 +879,9 @@ class BasicCommandHandler : Tracker {
 		} else  if(checkCommand(message, "spawntyphon")) {
 			spawnInstanceNearPlayer(senderId, "typhon.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnaek")) {
-			spawnInstanceNearPlayer(senderId, "aek999.vehicle", "vehicle", 0);		
+			spawnInstanceNearPlayer(senderId, "aek999.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnbsl")) {
-			spawnInstanceNearPlayer(senderId, "tricycle.vehicle", "vehicle", 0);		
+			spawnInstanceNearPlayer(senderId, "tricycle.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnbfg")) {
 			spawnInstanceNearPlayer(senderId, "kcco_BFG.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnchiara")) {
@@ -902,51 +905,51 @@ class BasicCommandHandler : Tracker {
 		} else  if(checkCommand(message, "spawnybc")) {
 			spawnInstanceNearPlayer(senderId, "kcco_trans_truck.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn my")) {
-			spawnInstanceNearPlayer(senderId, "par_elenusinus.vehicle", "vehicle", 0); 		
+			spawnInstanceNearPlayer(senderId, "par_elenusinus.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn aks")) {
 			spawnInstanceNearPlayer(senderId, "par_aceso.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn pickup")) {
 			spawnInstanceNearPlayer(senderId, "wastelander.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "spawn sgfq")) {
-			spawnInstanceNearPlayer(senderId, "par_cherub.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "par_cherub.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn k25")) {
-			spawnInstanceNearPlayer(senderId, "neosu_kuergants.vehicle", "vehicle", 0);		
+			spawnInstanceNearPlayer(senderId, "neosu_kuergants.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn kboss")) {
-			spawnInstanceNearPlayer(senderId, "neosu_kuergants_boss.vehicle", "vehicle", 0);									
+			spawnInstanceNearPlayer(senderId, "neosu_kuergants_boss.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn pathfinder")) {
-			spawnInstanceNearPlayer(senderId, "kcco_pathfinder_factory.vehicle", "vehicle", 0);			
+			spawnInstanceNearPlayer(senderId, "kcco_pathfinder_factory.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawn aegis")) {
-			spawnInstanceNearPlayer(senderId, "kcco_aa_aegis.vehicle", "vehicle", 0);			
+			spawnInstanceNearPlayer(senderId, "kcco_aa_aegis.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawneaegis")) {
-			spawnInstanceNearPlayer(senderId, "kcco_aa_aegis.vehicle", "vehicle", 1);			
+			spawnInstanceNearPlayer(senderId, "kcco_aa_aegis.vehicle", "vehicle", 1);
 		} else  if(checkCommand(message, "spawn m1abrams")) {
-			spawnInstanceNearPlayer(senderId, "tank_m1_base.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "tank_m1_base.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a12")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_2.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_2.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a13")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_3.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_3.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a14")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_4.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_4.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a15")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_5.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_5.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a16")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_6.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_6.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a17")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_7.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_7.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a18")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_8.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_8.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a19")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_9.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_9.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnm1a1")) {
-			spawnInstanceNearPlayer(senderId, "m1a1_off_test_fin.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "m1a1_off_test_fin.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnt14")) {
-			spawnInstanceNearPlayer(senderId, "t14_gk.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "t14_gk.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "spawnrabits")) {
-			spawnInstanceNearPlayer(senderId, "deploy_kit_rabits.weapon", "weapon", 0);				
+			spawnInstanceNearPlayer(senderId, "deploy_kit_rabits.weapon", "weapon", 0);
 		} else  if(checkCommand(message, "spawncrate")) {
-			spawnInstanceNearPlayer(senderId, "mortar_ammunition_crates.vehicle", "vehicle", 0);				
+			spawnInstanceNearPlayer(senderId, "mortar_ammunition_crates.vehicle", "vehicle", 0);
 		} else  if(checkCommand(message, "tph")) {
-			spawnInstanceNearPlayer(senderId, "para_heal_skill.projectile", "projectile", 0);			 						 						
+			spawnInstanceNearPlayer(senderId, "para_heal_skill.projectile", "projectile", 0);
 		} else if (checkCommand(message,"givetestweapon")){
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
 			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"weapon","ff_Intruder.weapon");
@@ -957,25 +960,25 @@ class BasicCommandHandler : Tracker {
 			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"carry_item","black_card.carry_item");
 			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"weapon","gkw_fedorov.weapon");
 			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"weapon","gkw_ump45.weapon");
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"weapon","gkw_ump45mod3.weapon");			
-		} else if (checkCommand(message,"gsft")){		
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"weapon","gkw_ump45mod3.weapon");
+		} else if (checkCommand(message,"gsft")){
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_arch_knight.projectile");	
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_arch_knight.projectile");					
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_arch_knight.projectile");					
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_oroborus_scan.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_oroborus_scan.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_hunter_scan.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_excutioner_scan.projectile");					
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_hunter_scan.projectile");			
-		}  else if (checkCommand(message,"tstnto")){		
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_arch_knight.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_arch_knight.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_arch_knight.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_oroborus_scan.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_oroborus_scan.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_hunter_scan.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_excutioner_scan.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","skill_sf_boss_hunter_scan.projectile");
+		}  else if (checkCommand(message,"tstnto")){
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");			
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","para_support_skill.projectile");
 		}
 		else if (checkCommand(message,"admintest")){
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
@@ -984,29 +987,29 @@ class BasicCommandHandler : Tracker {
 			string name = playerInfo.getStringAttribute("name");
 		} else if (checkCommand(message,"1919test")){
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
-			addMutilItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"carry_item","complete_box.carry_item",20);  			            			
+			addMutilItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"carry_item","complete_box.carry_item",20);
 		} else  if(checkCommand(message, "wound")) {
 			for (int i = 2; i < 100; ++i) {
 				string command =
 					"<command class='update_character'" +
 					"	id='" + i + "'" +
-					"	wounded='1'>" + 
+					"	wounded='1'>" +
 					"</command>";
 				m_metagame.getComms().send(command);
 			}
 		} else if (checkCommand(message, "fill")) {
 			fillInventory(senderId);
-		} else if (checkCommand(message,"gdiics")) {		
+		} else if (checkCommand(message,"gdiics")) {
 			const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
-			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");			
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
+			addItemInBackpack(m_metagame,playerInfo.getIntAttribute("character_id"),"projectile","gdiics.projectile");
 		}
 	}
 
@@ -1025,7 +1028,7 @@ class BasicCommandHandler : Tracker {
     void update(float time) {
         if(singLastTime>0){singLastTime-=time;}
     }
-	
+
 	// --------------------------------------------
 	void handleKick(string message, int senderId, bool id = false) {
 		const XmlElement@ player = getPlayerByIdOrNameFromCommand(m_metagame, message, id);
@@ -1042,17 +1045,17 @@ class BasicCommandHandler : Tracker {
 			sendPrivateMessage(m_metagame, senderId, "kick missed!");
 		}
 	}
-	
+
 	// --------------------------------------------
 	void handleSidInfo(string message, int senderId) {
 		// get name given as parameter
 		string name = message.substr(string("sidinfo ").length() + 1);
 
-		// assuming player name 
+		// assuming player name
 		// ask for player list from the server
 		array<const XmlElement@> playerList = getPlayers(m_metagame);
 		_log("* "  + playerList.size() + " players found");
-		
+
 		// go through the player list and match for the given name
 		bool foundFlag = false;
 		string playerSid = "";
@@ -1074,7 +1077,7 @@ class BasicCommandHandler : Tracker {
 			sendPrivateMessage(m_metagame, senderId, "player not found");
 		}
 	}
-	
+
 	// ----------------------------------------------------
 	protected void spawnInstanceNearPlayer(int senderId, string key, string type, int factionId = 0) {
 		const XmlElement@ playerInfo = getPlayerInfo(m_metagame, senderId);
@@ -1092,7 +1095,7 @@ class BasicCommandHandler : Tracker {
 	// ----------------------------------------------------
 	protected void destroyAllFactionVehicles(uint f, string key) {
 		array<const XmlElement@>@ vehicles = getVehicles(m_metagame, f, key);
-		
+
 		for (uint i = 0; i < vehicles.size(); ++i) {
 			const XmlElement@ vehicle = vehicles[i];
 			int id = vehicle.getIntAttribute("id");
@@ -1109,10 +1112,10 @@ class BasicCommandHandler : Tracker {
 
 	// ----------------------------------------------------
 	protected void addItem(XmlElement@ command, Resource@ r) {
-		XmlElement i("item"); 
-		i.setStringAttribute("class", r.m_type); 
-		i.setStringAttribute("key", r.m_key); 
-		command.appendChild(i); 
+		XmlElement i("item");
+		i.setStringAttribute("class", r.m_type);
+		i.setStringAttribute("key", r.m_key);
+		command.appendChild(i);
 	}
 
 	// ----------------------------------------------------
@@ -1125,7 +1128,7 @@ class BasicCommandHandler : Tracker {
 				XmlElement c("command");
 				c.setStringAttribute("class", "update_inventory");
 
-				c.setIntAttribute("character_id", characterId); 
+				c.setIntAttribute("character_id", characterId);
 				c.setStringAttribute("container_type_class", "backpack");
 				// create once instead of recreating three time
 				array<string> typeStr1 = {"weapon", "grenade", "carry_item"};
@@ -1139,7 +1142,7 @@ class BasicCommandHandler : Tracker {
 						}
 					}
 				}
-				
+
 				m_metagame.getComms().send(c);
 			}
 		}

--- a/packages/GFL_Castling/scripts/trackers/kill_event.as
+++ b/packages/GFL_Castling/scripts/trackers/kill_event.as
@@ -370,18 +370,18 @@ class kill_event : Tracker {
             int targetId = target.getIntAttribute("id");
             int factionId = killer.getIntAttribute("faction_id");
             int characterId = killer.getIntAttribute("id");
-            string solider_name = target.getStringAttribute("soldier_group_name");
+            string soldier_name = target.getStringAttribute("soldier_group_name");
             string dead_pos = target.getStringAttribute("position");
-            string reward_pool_key = getRewardPool(solider_name);
+            string reward_pool_key = getRewardPool(soldier_name);
             string KillerWeaponKey = event.getStringAttribute("key");
             string killway = event.getStringAttribute("method_hint");
 
-            if (startsWith(solider_name,"sf_goliath") && killway == "drive_over")
+            if (startsWith(soldier_name,"sf_goliath") && killway == "drive_over")
             {
                 spawnStaticProjectile(m_metagame,"goliath.projectile",dead_pos,targetId,target.getIntAttribute("faction_id"));
             }
 
-            if(factionId !=0 && (solider_name =="ar_378_scarl" || solider_name == "daybreak_squad") )
+            if(factionId !=0 && (soldier_name =="ar_378_scarl" || soldier_name == "daybreak_squad") )
             {
                 array<string> scarl = {"gkw_scarl.weapon","gkw_scarl_only.weapon"};
                 array<string> scarh = {"gkw_scarh.weapon","gkw_scarh_only.weapon"};
@@ -510,7 +510,7 @@ class kill_event : Tracker {
                 kill_to_heal_scale = 2;
                 notify(m_metagame, "kill streak,elite reward", dictionary(), "misc", playerId, false, "", 1.0);
             }
-            else if(point_nerfed_reward.find(solider_name) > -1)
+            else if(point_nerfed_reward.find(soldier_name) > -1)
             {
                 if(rand(0.0f,1.0f) <= 0.3f)
                 {
@@ -759,7 +759,7 @@ class kill_event : Tracker {
                 updateHealByKillEvent(characterId,factionId,10,20,"vest",kill_to_heal_scale);
             }
             else if(startsWith(c_armorType,"exo_t6") || startsWith(c_armorType,"dima_bunny")){
-                if(boss_list.find(solider_name)>-1){
+                if(boss_list.find(soldier_name)>-1){
                     healCharacter(m_metagame,characterId,5);
                 }
                 else if(reward_pool_key=="rare" || reward_pool_key=="elite")
@@ -920,20 +920,20 @@ class kill_event : Tracker {
 
             if(KillerWeaponKey=="blast_snipe_ff_hunter.projectile" && killway=="blast")
             {
-                if(eliteEnemyName.find(solider_name)>-1)
+                if(eliteEnemyName.find(soldier_name)>-1)
                 {
                     healCharacter(m_metagame,characterId,1);
                 }
             }
 
-            if (solider_name=="") return;
+            if (soldier_name=="") return;
 
-            if(SFbossList.find(solider_name)>-1 && characterId > 0){
+            if(SFbossList.find(soldier_name)>-1 && characterId > 0){
                 addCustomStatToCharacter(m_metagame,"sfboss_kill",characterId);
             }
 
-            int GivenRP = getRPKillReward(solider_name);
-            float GivenXP = getXPKillReward(solider_name);
+            int GivenRP = getRPKillReward(soldier_name);
+            float GivenXP = getXPKillReward(soldier_name);
             if(GivenRP>0){
                 givePlayerRPcount(playerId,GivenRP);
             }

--- a/packages/GFL_Castling/vehicles/invasion_all_vehicles.xml
+++ b/packages/GFL_Castling/vehicles/invasion_all_vehicles.xml
@@ -51,4 +51,5 @@
 	<vehicle file="sf_boss_intruder_skill.vehicle" />
 	<vehicle file="kcco_emp_jammer.vehicle" />
 	<vehicle file="daybreak_emp_jammer.vehicle" />
+	<vehicle file="qwd_spawn.vehicle" />
 </vehicles>

--- a/packages/GFL_Castling/vehicles/qwd_spawn.vehicle
+++ b/packages/GFL_Castling/vehicles/qwd_spawn.vehicle
@@ -1,42 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
-<vehicle name="flare" key="qwd_call.vehicle" map_view_atlas_index="0" allow_ai_to_use="0" should_be_destroyed="1" usable_for_cover="0" time_to_live="4" >
+<vehicle name="flare" key="qwd_spawn.vehicle" map_view_atlas_index="-1" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="0.1" >
 	<tire_set offset="0.1 0.0 0.1" radius="0.1" />
 	<tire_set offset="0.1 0.0 -0.1" radius="0.1" />
 
 	<control max_speed="20.0" acceleration="6.0" max_reverse_speed="5.0" max_rotation="0.8" max_water_depth="0.2" steer_smoothening="0.1" />
 
-	<physics max_health="4" mass="70.0" extent="0.2 0.0 0.2" offset="0 0.0 0" top_offset="0 0.5 0" collision_model_pos="0 0.2 0" collision_model_extent="0.6 0.2 0.6" visual_offset="0 0.0 0" destroy_on_top_hit="0" /> 
+	<physics max_health="1" blast_damage_threshold="10000.0" mass="10000.0" extent="0.2 0.0 0.2" offset="0 0.0 0" top_offset="0 0.5 0" collision_model_pos="0 40 0" collision_model_extent="0.0 0.0 0.0" visual_offset="0 0.0 0" destroy_on_top_hit="0" collision_response_factor="0.0" blast_push_threshold="1000.0" vehicle_collision_damage_factor="0.0" />
 
-	<visual class="chassis" mesh_filename="flare_stick.mesh" texture_filename="flare_stick_cyan.png" />
-<!--	<visual class="chassis" key="broken" mesh_filename="flare_stick.mesh" texture_filename="flare_stick_cyan.png" />  -->
-
-
-	<!-- sound handling -->
-	<rev_sound filename="truck_rev0.wav" low_pitch="0.95" high_pitch="1.05" low_rev="0.0" high_rev="0.2" volume="1.0" />
-	<rev_sound filename="truck_rev1.wav" low_pitch="0.8" high_pitch="1.1" low_rev="0.05" high_rev="0.7" volume="0.75" />
-	<rev_sound filename="truck_rev3.wav" low_pitch="0.8" high_pitch="1.1" low_rev="0.4" high_rev="1.0" volume="1.0" />
-
-
-	<effect event_key="idle_chassis" ref="FlareSparkle" post_processing="0" offset="0 0.1 0.3"/>
-	<effect event_key="idle_chassis" ref="FlareSmokeCyan" post_processing="0" offset="0 0.4 0.3"/>
-	<effect event_key="idle_chassis" ref="FlareFlashCyan" post_processing="0" offset="0 0.1 0.3"/> 
-
-	<effect event_key="destroy" key="other"  />
-
-   
-	<event key="receive_damage_xp_reward">
-		<trigger class="receive_damage" />
-		<result class="reward" xp="0.0070" />
-	</event>
-  
-	<event key="spot_rp_reward">
-		<trigger class="spot" />
-		<result class="reward" rp="30.0" />
-	</event>
-	
 	<event>
-		<trigger class="destroy" />		
-    		<result class="spawn" instance_class="solider" instance_key="sf_manticore" min_amount="2" max_amount="3" offset="0 0 0" />
-	</event> 
-  
+		<trigger class="destroy" />
+    	<result class="spawn" instance_class="projectile" instance_key="manticore_land_blast.projectile" min_amount="1" max_amount="1" offset="0 0.5 0" position_spread="0 0" direction_spread="0 0" />
+	</event>
+	<event>
+		<trigger class="destroy" />
+    	<result class="spawn" instance_class="soldier" instance_key="sf_manticore" min_amount="1" max_amount="1" offset="0 0 0" position_spread="0 0" direction_spread="0 0" />
+	</event>
+
 </vehicle>

--- a/packages/GFL_Castling/vehicles/smoke_grenade.vehicle
+++ b/packages/GFL_Castling/vehicles/smoke_grenade.vehicle
@@ -1,4 +1,4 @@
-<vehicle name="" key="smoke_grenade.vehicle" map_view_atlas_index="18" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="22.5" >
+<vehicle name="" key="smoke_grenade.vehicle" map_view_atlas_index="-1" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="22.5" >
 	<tire_set offset="0.1 0.0 0.1" radius="0.1" />
 	<tire_set offset="0.1 0.0 -0.1" radius="0.1" />
 

--- a/packages/GFL_Castling/vehicles/smoke_grenade_spawner.vehicle
+++ b/packages/GFL_Castling/vehicles/smoke_grenade_spawner.vehicle
@@ -1,4 +1,4 @@
-<vehicle name="" key="smoke_grenade_spawner.vehicle" map_view_atlas_index="18" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="0.1" >
+<vehicle name="" key="smoke_grenade_spawner.vehicle" map_view_atlas_index="-1" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="0.1" >
 	<tire_set offset="0.1 0.0 0.1" radius="0.1" />
 	<tire_set offset="0.1 0.0 -0.1" radius="0.1" />
 

--- a/packages/GFL_Castling/vehicles/smoke_grenade_v.vehicle
+++ b/packages/GFL_Castling/vehicles/smoke_grenade_v.vehicle
@@ -1,4 +1,4 @@
-<vehicle name="" key="smoke_grenade_v.vehicle" map_view_atlas_index="18" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="8.5" >
+<vehicle name="" key="smoke_grenade_v.vehicle" map_view_atlas_index="-1" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="8.5" >
 	<tire_set offset="0.1 0.0 0.1" radius="0.1" />
 	<tire_set offset="0.1 0.0 -0.1" radius="0.1" />
 

--- a/packages/GFL_Castling/vehicles/smoke_grenade_v_spawner.vehicle
+++ b/packages/GFL_Castling/vehicles/smoke_grenade_v_spawner.vehicle
@@ -1,4 +1,4 @@
-<vehicle name="" key="smoke_grenade_v_spawner.vehicle" map_view_atlas_index="18" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="0.1" >
+<vehicle name="" key="smoke_grenade_v_spawner.vehicle" map_view_atlas_index="-1" allow_ai_to_use="0" should_be_destroyed="0" usable_for_cover="0" respawn_time="36000" time_to_live="0.1" >
 	<tire_set offset="0.1 0.0 0.1" radius="0.1" />
 	<tire_set offset="0.1 0.0 -0.1" radius="0.1" />
 

--- a/packages/GFL_Castling/weapons/sfw_manticore_droppod.projectile
+++ b/packages/GFL_Castling/weapons/sfw_manticore_droppod.projectile
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <projectile class="grenade" name="Manticore Droppod" slot="1" pulldown_in_air="200.0" key="sfw_manticore_droppod.projectile">
     <tag name="grenade"/>
-    <result class="notify_script" key="manticore_summon" />
+    <!-- <result class="notify_script" key="manticore_summon" /> -->
+    <result class="spawn" instance_class="vehicle" instance_key="qwd_spawn.vehicle" min_amount="1" max_amount="1" offset="0 0.5 0" position_spread="0 0" direction_spread="0 0" />
     <trigger class="time" time_to_live="1.0">
 		<collision class="sticky" />
 	</trigger>


### PR DESCRIPTION
鉴于有人反映见到过m16摇蝎甲兽只掉空投仓不刷人的问题，注意到是因为call者死了character is null检测拦截导致的，故尝试用了一种不需要显式提供faction_id的古老方法（sfw_manticore_droppod.projectile -> qwd_spawn.vehicle -> manticore_land_blast.projectile / sf_manticore）做生成

预期是无论呼叫者死活都能生成出来，我测试没出问题，我不知道你原来为什么用这种方法会崩服，你可以再测一测

顺便改了个无关紧要的错别字和一堆空格