### PR TITLE
[fix] 为一些群体回甲技能临时添加特效 and 调整相关特效实现

### DIFF
--- a/packages/GFL_Castling/particles/ct_woosh.particle
+++ b/packages/GFL_Castling/particles/ct_woosh.particle
@@ -41,7 +41,10 @@ particle_system ct_heal_woosh
     particle_width 4
     particle_height 4
     renderer billboard 
-    billboard_type oriented_common
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
     common_up_vector 0 0 1 
 
     emitter Point 
@@ -77,7 +80,10 @@ particle_system ct_para_heal_woosh_6rad
     particle_width 6
     particle_height 6
     renderer billboard 
-    billboard_type oriented_common
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
     common_up_vector 0 0 1 
 
     emitter Point 
@@ -113,8 +119,11 @@ particle_system ct_para_nytro_support_woosh_12rad
     particle_width 12
     particle_height 6
     renderer billboard 
-    billboard_type oriented_common
-    common_up_vector 0 0 1 
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
+    common_up_vector 0 0 1
 
     emitter Point 
     {
@@ -150,7 +159,10 @@ particle_system ct_kcco_sniper_purple_woosh
     particle_width 9
     particle_height 9
     renderer billboard 
-    billboard_type oriented_common
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
     common_up_vector 0 0 1 
 
     emitter Point 
@@ -187,7 +199,10 @@ particle_system ct_kcco_sniper_yellow_woosh
     particle_width 12
     particle_height 12
     renderer billboard 
-    billboard_type oriented_common
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
     common_up_vector 0 0 1 
 
     emitter Point 
@@ -224,7 +239,10 @@ particle_system ct_kcco_sniper_red_woosh
     particle_width 20
     particle_height 20
     renderer billboard 
-    billboard_type oriented_common
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
     common_up_vector 0 0 1 
 
     emitter Point 
@@ -260,7 +278,10 @@ particle_system ct_heal_woosh_6rad
     particle_width 10
     particle_height 10
     renderer billboard 
-    billboard_type oriented_common
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
     common_up_vector 0 0 1 
 
     emitter Point 
@@ -296,8 +317,11 @@ particle_system ct_heal_woosh_10rad
     particle_width 10
     particle_height 10
     renderer billboard 
-    billboard_type oriented_common
-    common_up_vector 0 0 1 
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
+    common_up_vector 0 0 1
 
     emitter Point 
     {
@@ -332,8 +356,11 @@ particle_system ct_heal_woosh_25rad
     particle_width 10
     particle_height 10
     renderer billboard 
-    billboard_type oriented_common
-    common_up_vector 0 0 1 
+    billboard_type perpendicular_common
+    billboard_origin center
+    billboard_rotation_type vertex
+    common_direction 0 1 0
+    common_up_vector 0 0 1
 
     emitter Point 
     {

--- a/packages/GFL_Castling/scripts/trackers/commandskill.as
+++ b/packages/GFL_Castling/scripts/trackers/commandskill.as
@@ -724,6 +724,7 @@ class CommandSkill : Tracker {
                 c.setIntAttribute("untransform_count", 6);
                 m_metagame.getComms().send(c);
             }
+            spawnStaticProjectile(m_metagame,"particle_effect_radius_heal.projectile",c_pos,characterId,factionid);
             array<string> Voice={
                 "judge_skill_1.wav",
                 "judge_skill_2.wav"
@@ -748,6 +749,7 @@ class CommandSkill : Tracker {
                 c.setIntAttribute("untransform_count", 1);
                 m_metagame.getComms().send(c);
             }
+            spawnStaticProjectile(m_metagame,"particle_effect_radius_heal.projectile",c_pos,characterId,factionid);
             array<string> Voice={
                 "P22_SKILL1_JP.wav",
                 "P22_SKILL2_JP.wav",
@@ -773,6 +775,7 @@ class CommandSkill : Tracker {
                 c.setIntAttribute("untransform_count", 1);
                 m_metagame.getComms().send(c);
             }
+            spawnStaticProjectile(m_metagame,"particle_effect_radius_heal.projectile",c_pos,characterId,factionid);
             array<string> Voice={
                 "HS2000_SKILL1_JP.wav",
                 "HS2000_SKILL2_JP.wav",
@@ -4593,6 +4596,7 @@ class CommandSkill : Tracker {
                 c.setIntAttribute("untransform_count", 5);
                 m_metagame.getComms().send(c);
             }
+            spawnStaticProjectile(m_metagame,"particle_effect_radius_heal.projectile",c_pos,characterId,factionid);
             // array<string> Voice={
             // };
             // playRandomSoundArray(m_metagame,Voice,factionid,c_pos.toString(),1);
@@ -4764,6 +4768,7 @@ class CommandSkill : Tracker {
                 c.setIntAttribute("untransform_count", 3);
                 m_metagame.getComms().send(c);
             }
+            spawnStaticProjectile(m_metagame,"particle_effect_radius_heal.projectile",c_pos,characterId,factionid);
         }
     }
 


### PR DESCRIPTION
草率地给所有体回甲技能塞了生成费德洛夫弹药箱特效弹头（懒得算affector Scaler所以没有根据实际范围新写特效）

以及把相关woosh特效全换成了`billboard_type perpendicular_common`，因为感觉全都是原地爆开的特效，不需要`oriented_common`的来源方向性，这样还能确保大平地不会莫名其妙被地面吃一半特效