### PR TITLE
[chore] 79式mod3技能临时凑数 and 刽子手2模式技能回甲减少

### DIFF
--- a/packages/GFL_Castling/scripts/core/command_skill_info.as
+++ b/packages/GFL_Castling/scripts/core/command_skill_info.as
@@ -186,6 +186,8 @@ dictionary commandSkillIndex = {
         // Flashbang
         {"gkw_type79.weapon",27},
         {"gkw_type79_1402.weapon",27},
+        {"gkw_type79mod3.weapon",27},
+        {"gkw_type79mod3_1402.weapon",27},
         {"gkw_ump9.weapon",27},
         {"gkw_ump9_409.weapon",27},
         {"gkw_ump9_536.weapon",27},

--- a/packages/GFL_Castling/scripts/trackers/commandskill.as
+++ b/packages/GFL_Castling/scripts/trackers/commandskill.as
@@ -1021,7 +1021,7 @@ class CommandSkill : Tracker {
                 CreateProjectile(m_metagame,c_pos.add(Vector3(dx*dd*(ix*2)                    ,1,dy*dd*(ix*2)                    )),c_pos.add(Vector3(dx*dd*(ix*2)                    ,0,dy*dd*(ix*2)                    )),"excutioner_skill.projectile",characterId,factionid,100,0.001);
                 CreateProjectile(m_metagame,c_pos.add(Vector3(dx*dd*(ix*2-1)+dy*dd*(ix*2-1)/tt,1,dy*dd*(ix*2-1)-dx*dd*(ix*2-1)/tt)),c_pos.add(Vector3(dx*dd*(ix*2-1)+dy*dd*(ix*2-1)/tt,0,dy*dd*(ix*2-1)-dx*dd*(ix*2-1)/tt)),"excutioner_skill.projectile",characterId,factionid,100,0.001);
             }
-            healCharacter(m_metagame,characterId,4);
+            healCharacter(m_metagame,characterId,2);
         }
     }
 
@@ -2116,7 +2116,11 @@ class CommandSkill : Tracker {
                         playSoundAtLocation(m_metagame,"grenade_throw1.wav",factionid,c_pos,1.0);
                         addCooldown("Flashbang",16,characterId,modifer);
                     }
-                    if(weaponname=="gkw_type79.weapon" || weaponname=="gkw_type79_1402.weapon") {
+                    if(weaponname=="gkw_type79.weapon"
+                    || weaponname=="gkw_type79_1402.weapon"
+                    || weaponname=="gkw_type79mod3.weapon"
+                    || weaponname=="gkw_type79mod3_1402.weapon"
+                    ) {
                         array<string> Voice={
                             "79type_skilll1.wav",
                             "79type_skilll2.wav",


### PR DESCRIPTION
前者与 #113 相关，但未完成，只是共用了79的闪光弹技能凑数，你之后还是得做

后者涉及很长的讨论，G23认为既然已经长期造成了现在刽子手的性能就不应该在这么晚的时候再做削弱；我认为这个技能无条件回4甲相当不合理并且由于本身的杀回仍在对半砍不会大幅影响性能所以调了；这一点由你定夺

顺便还讨论了给白涅托加双防盾，G23认为即便加了双防也追不上刽子手所以加上没问题，我同意至少应该给blast death加上；但是因为上一个涉及皮肤的PR没收所以我没改；这个也由你决定