### PR TITLE
[fix] 两处小调整 哨戒塔楼锁andNVW动作

### DIFF
--- a/packages/GFL_Castling/vehicles/par_sentrytower.vehicle
+++ b/packages/GFL_Castling/vehicles/par_sentrytower.vehicle
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<vehicle name="Sentry Tower" key="par_sentrytower.vehicle" respawn_time="86400" map_view_atlas_index="52" minimum_fill_requirement="1.0" max_character_collision_speed_on_normal="8.0" max_character_collision_speed="8" character_leave_request_mode="friendly" existence="one_per_faction" allow_ai_to_use="1" allow_player_to_use="1" ai_driver_turns_to_target="0" allow_character_leave_request="0" protectors="5" soldier_capacity_offset="5" ai_stop_to_fight="0"  >
+<vehicle name="Sentry Tower" key="par_sentrytower.vehicle" respawn_time="86400" map_view_atlas_index="52" minimum_fill_requirement="1.0" max_character_collision_speed_on_normal="8.0" max_character_collision_speed="8" owner="faction" character_leave_request_mode="friendly" existence="one_per_faction" allow_ai_to_use="1" allow_player_to_use="1" ai_driver_turns_to_target="0" allow_character_leave_request="0" protectors="5" soldier_capacity_offset="5" ai_stop_to_fight="0"  >
 
     <tag name="only_aa" />
 	<tag name="target" />

--- a/packages/GFL_Castling/weapons/FF_sfw_architect_nvw.weapon
+++ b/packages/GFL_Castling/weapons/FF_sfw_architect_nvw.weapon
@@ -77,6 +77,10 @@
     <animation key="reload" stance_key="prone" animation_key="magBrifleRpntw" />
     <animation key="hold" animation_key="still, with law" />
     <animation key="hold_on_wall" animation_key="still, with law" />
+    <animation state_key="walking" animation_key="walking, hip fire" />
+    <animation state_key="running" animation_key="walking, hip fire" />
+    <animation state_key="crouch_moving" animation_key="crouching forwards, hip fire" />
+    <animation state_key="walking_backwards" animation_key="walking backwards, hip fire" />
     <sound key="fire" fileref="architect_fire_FromCOD15.wav" pitch_variety="0.00" volume="1.7"/>
     <sound key="cycle" fileref="Architectskill_cycle_FromCOD17.wav" />
     <sound key="magazine_out" fileref="Architectskill_mgz_out_FromCOD17.wav" />


### PR DESCRIPTION
1. 哨戒塔楼加了锁，避免自家人钻进去玩炸也不是不炸也不是的情况
2. 建筑师NVW2模式加了动作，没什么问题但是不加显得有一点点怪